### PR TITLE
refactor: move reflection features to Reflection.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shaderity",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import Reflection from './main/Reflection';
 import Shaderity from './main/Shaderity';
 import {AttributeSemantics, ReflectionAttribute, ReflectionUniform, ReflectionVarying, ShaderityObject, UniformSemantics, VarType} from './types/type';
 
@@ -11,7 +10,5 @@ export type {
   UniformSemantics,
   VarType,
 }
-
-export {Reflection};
 
 export default Shaderity

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -1,9 +1,41 @@
-import {ReflectionAttribute, ReflectionUniform, ReflectionVarying} from '../types/type';
+import {AttributeSemantics, ReflectionAttribute, ReflectionUniform, ReflectionVarying, ShaderStageStr, UniformSemantics, VarType} from '../types/type';
 
 export default class Reflection {
 	attributes: ReflectionAttribute[] = []
 	varyings: ReflectionVarying[] = [];
 	uniforms: ReflectionUniform[] = [];
+
+	private __attributeSemanticsMap = new Map();
+	private __uniformSemanticsMap = new Map();
+
+	private readonly __splittedShaderCode: string[];
+	private readonly __shaderStage: ShaderStageStr;
+
+	constructor(splittedShaderityShaderCode: string[], shaderStage: ShaderStageStr) {
+		this.__splittedShaderCode = splittedShaderityShaderCode;
+		this.__shaderStage = shaderStage;
+
+		this.__attributeSemanticsMap.set('position', 'POSITION');
+		this.__attributeSemanticsMap.set('color$', 'COLOR_0');
+		this.__attributeSemanticsMap.set('color_?0', 'COLOR_0');
+		this.__attributeSemanticsMap.set('texcoord$', 'TEXCOORD_0');
+		this.__attributeSemanticsMap.set('texcoord_?0', 'TEXCOORD_0');
+		this.__attributeSemanticsMap.set('texcoord_?1', 'TEXCOORD_1');
+		this.__attributeSemanticsMap.set('normal', 'NORMAL');
+		this.__attributeSemanticsMap.set('tangent', 'TANGENT');
+		this.__attributeSemanticsMap.set('joint$', 'JOINTS_0');
+		this.__attributeSemanticsMap.set('bone$', 'JOINTS_0');
+		this.__attributeSemanticsMap.set('joint_?0', 'JOINTS_0');
+		this.__attributeSemanticsMap.set('bone_?0', 'JOINTS_0');
+		this.__attributeSemanticsMap.set('weight$', 'WEIGHTS_0');
+		this.__attributeSemanticsMap.set('weight_?0', 'WEIGHTS_0');
+
+		this.__uniformSemanticsMap.set('worldmatrix', 'WorldMatrix');
+		this.__uniformSemanticsMap.set('normalmatrix', 'NormalMatrix');
+		this.__uniformSemanticsMap.set('viewmatrix', 'ViewMatrix');
+		this.__uniformSemanticsMap.set('projectionmatrix', 'ProjectionMatrix');
+		this.__uniformSemanticsMap.set('modelviewmatrix', 'ModelViewMatrix');
+	}
 
 	get attributesNames() {
 		return this.attributes.map((attribute) => {return attribute.name});
@@ -15,5 +47,107 @@ export default class Reflection {
 
 	get attributesTypes() {
 		return this.attributes.map((attribute) => {return attribute.type});
+	}
+
+	addAttributeSemanticsMap(map: Map<string, string>) {
+		this.__attributeSemanticsMap = new Map([...this.__attributeSemanticsMap, ...map]);
+	}
+
+	addUniformSemanticsMap(map: Map<string, string>) {
+		this.__uniformSemanticsMap = new Map([...this.__uniformSemanticsMap, ...map]);
+	}
+
+	reflect() {
+		const splittedShaderCode = this.__splittedShaderCode;
+		const shaderStage = this.__shaderStage;
+
+		const varTypes = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;
+		const varTypes2 = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4|sampler2D|samplerCube|sampler3D)[\t ]+(\w+);/;
+		const semanticRegExp = /<.*semantic[\t ]*=[\t ]*(\w+).*>/;
+		for (let row of splittedShaderCode) {
+			if (shaderStage === 'vertex') {
+				const attributeMatch = row.match(/^(?![\/])[\t ]*(attribute|in)[\t ]+.+;/);
+				if (attributeMatch) {
+					const reflectionAttribute: ReflectionAttribute = {
+						name: '',
+						type: 'float',
+						semantic: 'UNKNOWN'
+					};
+					const match = row.match(varTypes);
+					if (match) {
+						const type = match[1];
+						reflectionAttribute.type = type as VarType;
+						const name = match[2];
+						reflectionAttribute.name = name;
+
+						const match2 = row.match(semanticRegExp)
+						if (match2) {
+							reflectionAttribute.semantic = match2[1] as AttributeSemantics;
+						} else {
+							for (let [key, value] of this.__attributeSemanticsMap) {
+								if (name.match(new RegExp(key, 'i'))) {
+									reflectionAttribute.semantic = value;
+								}
+							}
+						}
+					}
+					this.attributes.push(reflectionAttribute);
+					continue;
+				}
+			}
+
+			let varyingMatch;
+			if (shaderStage === 'vertex') {
+				varyingMatch = row.match(/^(?![\/])[\t ]*(varying|out)[\t ]+.+;/);
+			} else {
+				varyingMatch = row.match(/^(?![\/])[\t ]*(varying|in)[\t ]+.+;/);
+			}
+			if (varyingMatch) {
+				const reflectionVarying: ReflectionVarying = {
+					name: '',
+					type: 'float',
+					inout: 'in'
+				};
+				const match = row.match(varTypes);
+				if (match) {
+					const type = match[1];
+					reflectionVarying.type = type as VarType;
+					const name = match[2];
+					reflectionVarying.name = name;
+					reflectionVarying.inout = (shaderStage === 'vertex') ? 'out' : 'in';
+				}
+				this.varyings.push(reflectionVarying);
+				continue;
+			}
+
+			const uniformMatch = row.match(/^(?![\/])[\t ]*uniform[\t ]+/);
+			if (uniformMatch) {
+				const reflectionUniform: ReflectionUniform = {
+					name: '',
+					type: 'float',
+					semantic: 'UNKNOWN'
+				};
+				const match = row.match(varTypes2);
+				if (match) {
+					const type = match[1];
+					reflectionUniform.type = type as VarType;
+					const name = match[2];
+					reflectionUniform.name = name;
+
+					const match2 = row.match(semanticRegExp)
+					if (match2) {
+						reflectionUniform.semantic = match2[1] as UniformSemantics;
+					} else {
+						for (let [key, value] of this.__uniformSemanticsMap) {
+							if (name.match(new RegExp(key, 'i'))) {
+								reflectionUniform.semantic = value;
+							}
+						}
+					}
+				}
+				this.uniforms.push(reflectionUniform);
+				continue;
+			}
+		}
 	}
 };

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -101,16 +101,17 @@ export default class Reflection {
 			type: 'float',
 			semantic: 'UNKNOWN'
 		};
-		const match = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
-		if (match) {
-			const type = match[1];
+
+		const matchType = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
+		if (matchType) {
+			const type = matchType[1];
 			reflectionAttribute.type = type as VarType;
-			const name = match[2];
+			const name = matchType[2];
 			reflectionAttribute.name = name;
 
-			const match2 = shaderCodeLine.match(Reflection.semanticRegExp)
-			if (match2) {
-				reflectionAttribute.semantic = match2[1] as AttributeSemantics;
+			const matchSemantic = shaderCodeLine.match(Reflection.semanticRegExp)
+			if (matchSemantic) {
+				reflectionAttribute.semantic = matchSemantic[1] as AttributeSemantics;
 			} else {
 				for (let [key, value] of this.__attributeSemanticsMap) {
 					if (name.match(new RegExp(key, 'i'))) {
@@ -136,11 +137,12 @@ export default class Reflection {
 			type: 'float',
 			inout: 'in'
 		};
-		const match = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
-		if (match) {
-			const type = match[1];
+
+		const matchType = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
+		if (matchType) {
+			const type = matchType[1];
 			reflectionVarying.type = type as VarType;
-			const name = match[2];
+			const name = matchType[2];
 			reflectionVarying.name = name;
 			reflectionVarying.inout = (shaderStage === 'vertex') ? 'out' : 'in';
 		}
@@ -153,16 +155,17 @@ export default class Reflection {
 			type: 'float',
 			semantic: 'UNKNOWN'
 		};
-		const match = shaderCodeLine.match(Reflection.uniformTypeRegExp);
-		if (match) {
-			const type = match[1];
+
+		const matchType = shaderCodeLine.match(Reflection.uniformTypeRegExp);
+		if (matchType) {
+			const type = matchType[1];
 			reflectionUniform.type = type as VarType;
-			const name = match[2];
+			const name = matchType[2];
 			reflectionUniform.name = name;
 
-			const match2 = shaderCodeLine.match(Reflection.semanticRegExp)
-			if (match2) {
-				reflectionUniform.semantic = match2[1] as UniformSemantics;
+			const matchSemantics = shaderCodeLine.match(Reflection.semanticRegExp)
+			if (matchSemantics) {
+				reflectionUniform.semantic = matchSemantics[1] as UniformSemantics;
 			} else {
 				for (let [key, value] of this.__uniformSemanticsMap) {
 					if (name.match(new RegExp(key, 'i'))) {

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -64,23 +64,23 @@ export default class Reflection {
 		const varTypes = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;
 		const varTypes2 = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4|sampler2D|samplerCube|sampler3D)[\t ]+(\w+);/;
 		const semanticRegExp = /<.*semantic[\t ]*=[\t ]*(\w+).*>/;
-		for (let row of splittedShaderCode) {
+		for (const shaderCodeLine of splittedShaderCode) {
 			if (shaderStage === 'vertex') {
-				const attributeMatch = row.match(/^(?![\/])[\t ]*(attribute|in)[\t ]+.+;/);
+				const attributeMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(attribute|in)[\t ]+.+;/);
 				if (attributeMatch) {
 					const reflectionAttribute: ReflectionAttribute = {
 						name: '',
 						type: 'float',
 						semantic: 'UNKNOWN'
 					};
-					const match = row.match(varTypes);
+					const match = shaderCodeLine.match(varTypes);
 					if (match) {
 						const type = match[1];
 						reflectionAttribute.type = type as VarType;
 						const name = match[2];
 						reflectionAttribute.name = name;
 
-						const match2 = row.match(semanticRegExp)
+						const match2 = shaderCodeLine.match(semanticRegExp)
 						if (match2) {
 							reflectionAttribute.semantic = match2[1] as AttributeSemantics;
 						} else {
@@ -98,9 +98,9 @@ export default class Reflection {
 
 			let varyingMatch;
 			if (shaderStage === 'vertex') {
-				varyingMatch = row.match(/^(?![\/])[\t ]*(varying|out)[\t ]+.+;/);
+				varyingMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(varying|out)[\t ]+.+;/);
 			} else {
-				varyingMatch = row.match(/^(?![\/])[\t ]*(varying|in)[\t ]+.+;/);
+				varyingMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(varying|in)[\t ]+.+;/);
 			}
 			if (varyingMatch) {
 				const reflectionVarying: ReflectionVarying = {
@@ -108,7 +108,7 @@ export default class Reflection {
 					type: 'float',
 					inout: 'in'
 				};
-				const match = row.match(varTypes);
+				const match = shaderCodeLine.match(varTypes);
 				if (match) {
 					const type = match[1];
 					reflectionVarying.type = type as VarType;
@@ -120,21 +120,21 @@ export default class Reflection {
 				continue;
 			}
 
-			const uniformMatch = row.match(/^(?![\/])[\t ]*uniform[\t ]+/);
+			const uniformMatch = shaderCodeLine.match(/^(?![\/])[\t ]*uniform[\t ]+/);
 			if (uniformMatch) {
 				const reflectionUniform: ReflectionUniform = {
 					name: '',
 					type: 'float',
 					semantic: 'UNKNOWN'
 				};
-				const match = row.match(varTypes2);
+				const match = shaderCodeLine.match(varTypes2);
 				if (match) {
 					const type = match[1];
 					reflectionUniform.type = type as VarType;
 					const name = match[2];
 					reflectionUniform.name = name;
 
-					const match2 = row.match(semanticRegExp)
+					const match2 = shaderCodeLine.match(semanticRegExp)
 					if (match2) {
 						reflectionUniform.semantic = match2[1] as UniformSemantics;
 					} else {

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -5,6 +5,12 @@ export default class Reflection {
 	varyings: ReflectionVarying[] = [];
 	uniforms: ReflectionUniform[] = [];
 
+	private static readonly attributeAndVaryingTypeRegExp
+		= /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;
+	private static readonly uniformTypeRegExp
+		= /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4|sampler2D|samplerCube|sampler3D)[\t ]+(\w+);/;
+	private static readonly semanticRegExp = /<.*semantic[\t ]*=[\t ]*(\w+).*>/;
+
 	private __attributeSemanticsMap = new Map();
 	private __uniformSemanticsMap = new Map();
 
@@ -61,11 +67,6 @@ export default class Reflection {
 		const splittedShaderCode = this.__splittedShaderCode;
 		const shaderStage = this.__shaderStage;
 
-		const attributeAndVaryingTypeRegExp
-			= /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;
-		const uniformTypeRegExp
-			= /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4|sampler2D|samplerCube|sampler3D)[\t ]+(\w+);/;
-		const semanticRegExp = /<.*semantic[\t ]*=[\t ]*(\w+).*>/;
 		for (const shaderCodeLine of splittedShaderCode) {
 			if (shaderStage === 'vertex') {
 				const attributeMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(attribute|in)[\t ]+.+;/);
@@ -75,14 +76,14 @@ export default class Reflection {
 						type: 'float',
 						semantic: 'UNKNOWN'
 					};
-					const match = shaderCodeLine.match(attributeAndVaryingTypeRegExp);
+					const match = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
 					if (match) {
 						const type = match[1];
 						reflectionAttribute.type = type as VarType;
 						const name = match[2];
 						reflectionAttribute.name = name;
 
-						const match2 = shaderCodeLine.match(semanticRegExp)
+						const match2 = shaderCodeLine.match(Reflection.semanticRegExp)
 						if (match2) {
 							reflectionAttribute.semantic = match2[1] as AttributeSemantics;
 						} else {
@@ -110,7 +111,7 @@ export default class Reflection {
 					type: 'float',
 					inout: 'in'
 				};
-				const match = shaderCodeLine.match(attributeAndVaryingTypeRegExp);
+				const match = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
 				if (match) {
 					const type = match[1];
 					reflectionVarying.type = type as VarType;
@@ -129,14 +130,14 @@ export default class Reflection {
 					type: 'float',
 					semantic: 'UNKNOWN'
 				};
-				const match = shaderCodeLine.match(uniformTypeRegExp);
+				const match = shaderCodeLine.match(Reflection.uniformTypeRegExp);
 				if (match) {
 					const type = match[1];
 					reflectionUniform.type = type as VarType;
 					const name = match[2];
 					reflectionUniform.name = name;
 
-					const match2 = shaderCodeLine.match(semanticRegExp)
+					const match2 = shaderCodeLine.match(Reflection.semanticRegExp)
 					if (match2) {
 						reflectionUniform.semantic = match2[1] as UniformSemantics;
 					} else {

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -71,30 +71,7 @@ export default class Reflection {
 			if (shaderStage === 'vertex') {
 				const attributeMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(attribute|in)[\t ]+.+;/);
 				if (attributeMatch) {
-					const reflectionAttribute: ReflectionAttribute = {
-						name: '',
-						type: 'float',
-						semantic: 'UNKNOWN'
-					};
-					const match = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
-					if (match) {
-						const type = match[1];
-						reflectionAttribute.type = type as VarType;
-						const name = match[2];
-						reflectionAttribute.name = name;
-
-						const match2 = shaderCodeLine.match(Reflection.semanticRegExp)
-						if (match2) {
-							reflectionAttribute.semantic = match2[1] as AttributeSemantics;
-						} else {
-							for (let [key, value] of this.__attributeSemanticsMap) {
-								if (name.match(new RegExp(key, 'i'))) {
-									reflectionAttribute.semantic = value;
-								}
-							}
-						}
-					}
-					this.attributes.push(reflectionAttribute);
+					this.__addAttribute(shaderCodeLine);
 					continue;
 				}
 			}
@@ -106,51 +83,86 @@ export default class Reflection {
 				varyingMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(varying|in)[\t ]+.+;/);
 			}
 			if (varyingMatch) {
-				const reflectionVarying: ReflectionVarying = {
-					name: '',
-					type: 'float',
-					inout: 'in'
-				};
-				const match = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
-				if (match) {
-					const type = match[1];
-					reflectionVarying.type = type as VarType;
-					const name = match[2];
-					reflectionVarying.name = name;
-					reflectionVarying.inout = (shaderStage === 'vertex') ? 'out' : 'in';
-				}
-				this.varyings.push(reflectionVarying);
+				this.__addVarying(shaderCodeLine, shaderStage);
 				continue;
 			}
 
 			const uniformMatch = shaderCodeLine.match(/^(?![\/])[\t ]*uniform[\t ]+/);
 			if (uniformMatch) {
-				const reflectionUniform: ReflectionUniform = {
-					name: '',
-					type: 'float',
-					semantic: 'UNKNOWN'
-				};
-				const match = shaderCodeLine.match(Reflection.uniformTypeRegExp);
-				if (match) {
-					const type = match[1];
-					reflectionUniform.type = type as VarType;
-					const name = match[2];
-					reflectionUniform.name = name;
-
-					const match2 = shaderCodeLine.match(Reflection.semanticRegExp)
-					if (match2) {
-						reflectionUniform.semantic = match2[1] as UniformSemantics;
-					} else {
-						for (let [key, value] of this.__uniformSemanticsMap) {
-							if (name.match(new RegExp(key, 'i'))) {
-								reflectionUniform.semantic = value;
-							}
-						}
-					}
-				}
-				this.uniforms.push(reflectionUniform);
+				this.__addUniform(shaderCodeLine);
 				continue;
 			}
 		}
+	}
+
+	private __addAttribute(shaderCodeLine: string) {
+		const reflectionAttribute: ReflectionAttribute = {
+			name: '',
+			type: 'float',
+			semantic: 'UNKNOWN'
+		};
+		const match = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
+		if (match) {
+			const type = match[1];
+			reflectionAttribute.type = type as VarType;
+			const name = match[2];
+			reflectionAttribute.name = name;
+
+			const match2 = shaderCodeLine.match(Reflection.semanticRegExp)
+			if (match2) {
+				reflectionAttribute.semantic = match2[1] as AttributeSemantics;
+			} else {
+				for (let [key, value] of this.__attributeSemanticsMap) {
+					if (name.match(new RegExp(key, 'i'))) {
+						reflectionAttribute.semantic = value;
+					}
+				}
+			}
+		}
+		this.attributes.push(reflectionAttribute);
+	}
+
+	private __addVarying(shaderCodeLine: string, shaderStage: ShaderStageStr) {
+		const reflectionVarying: ReflectionVarying = {
+			name: '',
+			type: 'float',
+			inout: 'in'
+		};
+		const match = shaderCodeLine.match(Reflection.attributeAndVaryingTypeRegExp);
+		if (match) {
+			const type = match[1];
+			reflectionVarying.type = type as VarType;
+			const name = match[2];
+			reflectionVarying.name = name;
+			reflectionVarying.inout = (shaderStage === 'vertex') ? 'out' : 'in';
+		}
+		this.varyings.push(reflectionVarying);
+	}
+
+	private __addUniform(shaderCodeLine: string) {
+		const reflectionUniform: ReflectionUniform = {
+			name: '',
+			type: 'float',
+			semantic: 'UNKNOWN'
+		};
+		const match = shaderCodeLine.match(Reflection.uniformTypeRegExp);
+		if (match) {
+			const type = match[1];
+			reflectionUniform.type = type as VarType;
+			const name = match[2];
+			reflectionUniform.name = name;
+
+			const match2 = shaderCodeLine.match(Reflection.semanticRegExp)
+			if (match2) {
+				reflectionUniform.semantic = match2[1] as UniformSemantics;
+			} else {
+				for (let [key, value] of this.__uniformSemanticsMap) {
+					if (name.match(new RegExp(key, 'i'))) {
+						reflectionUniform.semantic = value;
+					}
+				}
+			}
+		}
+		this.uniforms.push(reflectionUniform);
 	}
 };

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -1,8 +1,6 @@
 import {AttributeSemantics, ReflectionAttribute, ReflectionUniform, ReflectionVarying, ShaderStageStr, UniformSemantics, VarType} from '../types/type';
 
 export default class Reflection {
-	uniforms: ReflectionUniform[] = [];
-
 	private static readonly attributeAndVaryingTypeRegExp
 		= /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;
 	private static readonly uniformTypeRegExp
@@ -13,6 +11,7 @@ export default class Reflection {
 	private __uniformSemanticsMap = new Map();
 	private __attributes: ReflectionAttribute[] = [];
 	private __varyings: ReflectionVarying[] = [];
+	private __uniforms: ReflectionUniform[] = [];
 
 	private readonly __splittedShaderCode: string[];
 	private readonly __shaderStage: ShaderStageStr;
@@ -49,6 +48,10 @@ export default class Reflection {
 
 	get varyings() {
 		return this.__varyings;
+	}
+
+	get uniforms() {
+		return this.__uniforms;
 	}
 
 	get attributesNames() {
@@ -182,6 +185,6 @@ export default class Reflection {
 				}
 			}
 		}
-		this.uniforms.push(reflectionUniform);
+		this.__uniforms.push(reflectionUniform);
 	}
 };

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -7,8 +7,8 @@ export default class Reflection {
 		= /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4|sampler2D|samplerCube|sampler3D)[\t ]+(\w+);/;
 	private static readonly semanticRegExp = /<.*semantic[\t ]*=[\t ]*(\w+).*>/;
 
-	private __attributeSemanticsMap = new Map();
-	private __uniformSemanticsMap = new Map();
+	private __attributeSemanticsMap = new Map<string, string>();
+	private __uniformSemanticsMap = new Map<string, string>();
 	private __attributes: ReflectionAttribute[] = [];
 	private __varyings: ReflectionVarying[] = [];
 	private __uniforms: ReflectionUniform[] = [];
@@ -129,7 +129,7 @@ export default class Reflection {
 			} else {
 				for (let [key, value] of this.__attributeSemanticsMap) {
 					if (name.match(new RegExp(key, 'i'))) {
-						reflectionAttribute.semantic = value;
+						reflectionAttribute.semantic = value as AttributeSemantics;
 					}
 				}
 			}

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -68,31 +68,31 @@ export default class Reflection {
 		const shaderStage = this.__shaderStage;
 
 		for (const shaderCodeLine of splittedShaderCode) {
-			if (shaderStage === 'vertex') {
-				const attributeMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(attribute|in)[\t ]+.+;/);
-				if (attributeMatch) {
-					this.__addAttribute(shaderCodeLine);
-					continue;
-				}
+			const isAttributeLine = this.__matchAttribute(shaderCodeLine, shaderStage);
+			if (isAttributeLine) {
+				this.__addAttribute(shaderCodeLine);
+				continue;
 			}
 
-			let varyingMatch;
-			if (shaderStage === 'vertex') {
-				varyingMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(varying|out)[\t ]+.+;/);
-			} else {
-				varyingMatch = shaderCodeLine.match(/^(?![\/])[\t ]*(varying|in)[\t ]+.+;/);
-			}
-			if (varyingMatch) {
+			const isVaryingLine = this.__matchVarying(shaderCodeLine, shaderStage);
+			if (isVaryingLine) {
 				this.__addVarying(shaderCodeLine, shaderStage);
 				continue;
 			}
 
-			const uniformMatch = shaderCodeLine.match(/^(?![\/])[\t ]*uniform[\t ]+/);
-			if (uniformMatch) {
+			const isUniformLine = shaderCodeLine.match(/^(?![\/])[\t ]*uniform[\t ]+/);
+			if (isUniformLine) {
 				this.__addUniform(shaderCodeLine);
 				continue;
 			}
 		}
+	}
+
+	private __matchAttribute(shaderCodeLine: string, shaderStage: ShaderStageStr) {
+		if (shaderStage !== 'vertex') {
+			return false;
+		}
+		return shaderCodeLine.match(/^(?![\/])[\t ]*(attribute|in)[\t ]+.+;/);
 	}
 
 	private __addAttribute(shaderCodeLine: string) {
@@ -120,6 +120,14 @@ export default class Reflection {
 			}
 		}
 		this.attributes.push(reflectionAttribute);
+	}
+
+	private __matchVarying(shaderCodeLine: string, shaderStage: ShaderStageStr) {
+		if (shaderStage === 'vertex') {
+			return shaderCodeLine.match(/^(?![\/])[\t ]*(varying|out)[\t ]+.+;/);
+		} else {
+			return shaderCodeLine.match(/^(?![\/])[\t ]*(varying|in)[\t ]+.+;/);
+		}
 	}
 
 	private __addVarying(shaderCodeLine: string, shaderStage: ShaderStageStr) {

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -1,7 +1,6 @@
 import {AttributeSemantics, ReflectionAttribute, ReflectionUniform, ReflectionVarying, ShaderStageStr, UniformSemantics, VarType} from '../types/type';
 
 export default class Reflection {
-	attributes: ReflectionAttribute[] = []
 	varyings: ReflectionVarying[] = [];
 	uniforms: ReflectionUniform[] = [];
 
@@ -13,6 +12,7 @@ export default class Reflection {
 
 	private __attributeSemanticsMap = new Map();
 	private __uniformSemanticsMap = new Map();
+	private __attributes: ReflectionAttribute[] = [];
 
 	private readonly __splittedShaderCode: string[];
 	private readonly __shaderStage: ShaderStageStr;
@@ -43,16 +43,20 @@ export default class Reflection {
 		this.__uniformSemanticsMap.set('modelviewmatrix', 'ModelViewMatrix');
 	}
 
+	get attributes() {
+		return this.__attributes;
+	}
+
 	get attributesNames() {
-		return this.attributes.map((attribute) => {return attribute.name});
+		return this.__attributes.map((attribute) => {return attribute.name});
 	}
 
 	get attributesSemantics() {
-		return this.attributes.map((attribute) => {return attribute.semantic});
+		return this.__attributes.map((attribute) => {return attribute.semantic});
 	}
 
 	get attributesTypes() {
-		return this.attributes.map((attribute) => {return attribute.type});
+		return this.__attributes.map((attribute) => {return attribute.type});
 	}
 
 	addAttributeSemanticsMap(map: Map<string, string>) {
@@ -120,7 +124,7 @@ export default class Reflection {
 				}
 			}
 		}
-		this.attributes.push(reflectionAttribute);
+		this.__attributes.push(reflectionAttribute);
 	}
 
 	private __matchVarying(shaderCodeLine: string, shaderStage: ShaderStageStr) {

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -61,8 +61,10 @@ export default class Reflection {
 		const splittedShaderCode = this.__splittedShaderCode;
 		const shaderStage = this.__shaderStage;
 
-		const varTypes = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;
-		const varTypes2 = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4|sampler2D|samplerCube|sampler3D)[\t ]+(\w+);/;
+		const attributeAndVaryingTypeRegExp
+			= /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;
+		const uniformTypeRegExp
+			= /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4|sampler2D|samplerCube|sampler3D)[\t ]+(\w+);/;
 		const semanticRegExp = /<.*semantic[\t ]*=[\t ]*(\w+).*>/;
 		for (const shaderCodeLine of splittedShaderCode) {
 			if (shaderStage === 'vertex') {
@@ -73,7 +75,7 @@ export default class Reflection {
 						type: 'float',
 						semantic: 'UNKNOWN'
 					};
-					const match = shaderCodeLine.match(varTypes);
+					const match = shaderCodeLine.match(attributeAndVaryingTypeRegExp);
 					if (match) {
 						const type = match[1];
 						reflectionAttribute.type = type as VarType;
@@ -108,7 +110,7 @@ export default class Reflection {
 					type: 'float',
 					inout: 'in'
 				};
-				const match = shaderCodeLine.match(varTypes);
+				const match = shaderCodeLine.match(attributeAndVaryingTypeRegExp);
 				if (match) {
 					const type = match[1];
 					reflectionVarying.type = type as VarType;
@@ -127,7 +129,7 @@ export default class Reflection {
 					type: 'float',
 					semantic: 'UNKNOWN'
 				};
-				const match = shaderCodeLine.match(varTypes2);
+				const match = shaderCodeLine.match(uniformTypeRegExp);
 				if (match) {
 					const type = match[1];
 					reflectionUniform.type = type as VarType;

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -1,7 +1,6 @@
 import {AttributeSemantics, ReflectionAttribute, ReflectionUniform, ReflectionVarying, ShaderStageStr, UniformSemantics, VarType} from '../types/type';
 
 export default class Reflection {
-	varyings: ReflectionVarying[] = [];
 	uniforms: ReflectionUniform[] = [];
 
 	private static readonly attributeAndVaryingTypeRegExp
@@ -13,6 +12,7 @@ export default class Reflection {
 	private __attributeSemanticsMap = new Map();
 	private __uniformSemanticsMap = new Map();
 	private __attributes: ReflectionAttribute[] = [];
+	private __varyings: ReflectionVarying[] = [];
 
 	private readonly __splittedShaderCode: string[];
 	private readonly __shaderStage: ShaderStageStr;
@@ -45,6 +45,10 @@ export default class Reflection {
 
 	get attributes() {
 		return this.__attributes;
+	}
+
+	get varyings() {
+		return this.__varyings;
 	}
 
 	get attributesNames() {
@@ -150,7 +154,7 @@ export default class Reflection {
 			reflectionVarying.name = name;
 			reflectionVarying.inout = (shaderStage === 'vertex') ? 'out' : 'in';
 		}
-		this.varyings.push(reflectionVarying);
+		this.__varyings.push(reflectionVarying);
 	}
 
 	private __addUniform(shaderCodeLine: string) {

--- a/src/main/Reflection.ts
+++ b/src/main/Reflection.ts
@@ -19,27 +19,7 @@ export default class Reflection {
 	constructor(splittedShaderityShaderCode: string[], shaderStage: ShaderStageStr) {
 		this.__splittedShaderCode = splittedShaderityShaderCode;
 		this.__shaderStage = shaderStage;
-
-		this.__attributeSemanticsMap.set('position', 'POSITION');
-		this.__attributeSemanticsMap.set('color$', 'COLOR_0');
-		this.__attributeSemanticsMap.set('color_?0', 'COLOR_0');
-		this.__attributeSemanticsMap.set('texcoord$', 'TEXCOORD_0');
-		this.__attributeSemanticsMap.set('texcoord_?0', 'TEXCOORD_0');
-		this.__attributeSemanticsMap.set('texcoord_?1', 'TEXCOORD_1');
-		this.__attributeSemanticsMap.set('normal', 'NORMAL');
-		this.__attributeSemanticsMap.set('tangent', 'TANGENT');
-		this.__attributeSemanticsMap.set('joint$', 'JOINTS_0');
-		this.__attributeSemanticsMap.set('bone$', 'JOINTS_0');
-		this.__attributeSemanticsMap.set('joint_?0', 'JOINTS_0');
-		this.__attributeSemanticsMap.set('bone_?0', 'JOINTS_0');
-		this.__attributeSemanticsMap.set('weight$', 'WEIGHTS_0');
-		this.__attributeSemanticsMap.set('weight_?0', 'WEIGHTS_0');
-
-		this.__uniformSemanticsMap.set('worldmatrix', 'WorldMatrix');
-		this.__uniformSemanticsMap.set('normalmatrix', 'NormalMatrix');
-		this.__uniformSemanticsMap.set('viewmatrix', 'ViewMatrix');
-		this.__uniformSemanticsMap.set('projectionmatrix', 'ProjectionMatrix');
-		this.__uniformSemanticsMap.set('modelviewmatrix', 'ModelViewMatrix');
+		this.__setDefaultAttributeAndUniformSemanticsMap();
 	}
 
 	get attributes() {
@@ -97,6 +77,29 @@ export default class Reflection {
 				continue;
 			}
 		}
+	}
+
+	private __setDefaultAttributeAndUniformSemanticsMap() {
+		this.__attributeSemanticsMap.set('position', 'POSITION');
+		this.__attributeSemanticsMap.set('color$', 'COLOR_0');
+		this.__attributeSemanticsMap.set('color_?0', 'COLOR_0');
+		this.__attributeSemanticsMap.set('texcoord$', 'TEXCOORD_0');
+		this.__attributeSemanticsMap.set('texcoord_?0', 'TEXCOORD_0');
+		this.__attributeSemanticsMap.set('texcoord_?1', 'TEXCOORD_1');
+		this.__attributeSemanticsMap.set('normal', 'NORMAL');
+		this.__attributeSemanticsMap.set('tangent', 'TANGENT');
+		this.__attributeSemanticsMap.set('joint$', 'JOINTS_0');
+		this.__attributeSemanticsMap.set('bone$', 'JOINTS_0');
+		this.__attributeSemanticsMap.set('joint_?0', 'JOINTS_0');
+		this.__attributeSemanticsMap.set('bone_?0', 'JOINTS_0');
+		this.__attributeSemanticsMap.set('weight$', 'WEIGHTS_0');
+		this.__attributeSemanticsMap.set('weight_?0', 'WEIGHTS_0');
+
+		this.__uniformSemanticsMap.set('worldmatrix', 'WorldMatrix');
+		this.__uniformSemanticsMap.set('normalmatrix', 'NormalMatrix');
+		this.__uniformSemanticsMap.set('viewmatrix', 'ViewMatrix');
+		this.__uniformSemanticsMap.set('projectionmatrix', 'ProjectionMatrix');
+		this.__uniformSemanticsMap.set('modelviewmatrix', 'ModelViewMatrix');
 	}
 
 	private __matchAttribute(shaderCodeLine: string, shaderStage: ShaderStageStr) {

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -235,7 +235,7 @@ export default class Shaderity {
 	transformToGLSLES1(obj: ShaderityObject) {
 		const copy = this.copyShaderityObject(obj);
 
-		let splited = this._splitShaderCode(obj.code);
+		let splited = this._splitByLineFeedCode(obj.code);
 
 		this._convertIn(obj, splited);
 		this._convertOut(obj, splited);
@@ -251,7 +251,7 @@ export default class Shaderity {
 	transformToGLSLES3(obj: ShaderityObject) {
 		const copy = this.copyShaderityObject(obj);
 
-		let splited = this._splitShaderCode(obj.code);
+		let splited = this._splitByLineFeedCode(obj.code);
 
 		this._convertAttribute(obj, splited);
 		this._convertVarying(obj, splited);
@@ -275,7 +275,7 @@ export default class Shaderity {
 		}
 	}
 
-	private _splitShaderCode(source: string) {
+	private _splitByLineFeedCode(source: string) {
 		return source.split(/\r\n|\n/);
 	}
 
@@ -305,7 +305,7 @@ export default class Shaderity {
 
 	insertDefinition(obj: ShaderityObject, definition: string) {
 		const copy = this.copyShaderityObject(obj);
-		let splited = this._splitShaderCode(obj.code);
+		let splited = this._splitByLineFeedCode(obj.code);
 
 		const defStr = definition.replace(/#define[\t ]+/, '');
 
@@ -317,7 +317,7 @@ export default class Shaderity {
 	}
 
 	reflect(obj: ShaderityObject): Reflection {
-		let splited = this._splitShaderCode(obj.code);
+		let splited = this._splitByLineFeedCode(obj.code);
 
 		const reflection = new Reflection();
 		const varTypes = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -235,15 +235,15 @@ export default class Shaderity {
 	transformToGLSLES1(obj: ShaderityObject) {
 		const copy = this.copyShaderityObject(obj);
 
-		let splited = this._splitByLineFeedCode(obj.code);
+		let splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
-		this._convertIn(obj, splited);
-		this._convertOut(obj, splited);
-		this._removeLayout(obj, splited);
+		this._convertIn(obj, splittedShaderCode);
+		this._convertOut(obj, splittedShaderCode);
+		this._removeLayout(obj, splittedShaderCode);
 
-		splited = this._convertTextureFunctionToES1(splited);
+		splittedShaderCode = this._convertTextureFunctionToES1(splittedShaderCode);
 
-		copy.code = this._joinSplitedRow(splited);
+		copy.code = this._joinSplitedRow(splittedShaderCode);
 
 		return copy;
 	}
@@ -251,15 +251,15 @@ export default class Shaderity {
 	transformToGLSLES3(obj: ShaderityObject) {
 		const copy = this.copyShaderityObject(obj);
 
-		let splited = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
-		this._convertAttribute(obj, splited);
-		this._convertVarying(obj, splited);
-		this._convertTexture2D(obj, splited);
-		this._convertTextureCube(obj, splited);
-		this._convertTexture2DProd(obj, splited);
+		this._convertAttribute(obj, splittedShaderCode);
+		this._convertVarying(obj, splittedShaderCode);
+		this._convertTexture2D(obj, splittedShaderCode);
+		this._convertTextureCube(obj, splittedShaderCode);
+		this._convertTexture2DProd(obj, splittedShaderCode);
 
-		copy.code = this._joinSplitedRow(splited);
+		copy.code = this._joinSplitedRow(splittedShaderCode);
 
 		return copy;
 	}
@@ -305,25 +305,25 @@ export default class Shaderity {
 
 	insertDefinition(obj: ShaderityObject, definition: string) {
 		const copy = this.copyShaderityObject(obj);
-		let splited = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const defStr = definition.replace(/#define[\t ]+/, '');
 
-		splited.unshift(`#define ${defStr}`);
+		splittedShaderCode.unshift(`#define ${defStr}`);
 
-		copy.code = this._joinSplitedRow(splited);
+		copy.code = this._joinSplitedRow(splittedShaderCode);
 
 		return copy;
 	}
 
 	reflect(obj: ShaderityObject): Reflection {
-		let splited = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const reflection = new Reflection();
 		const varTypes = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4)[\t ]+(\w+);/;
 		const varTypes2 = /[\t ]+(float|int|vec2|vec3|vec4|mat2|mat3|mat4|ivec2|ivec3|ivec4|sampler2D|samplerCube|sampler3D)[\t ]+(\w+);/;
 		const semanticRegExp = /<.*semantic[\t ]*=[\t ]*(\w+).*>/;
-		for (let row of splited) {
+		for (let row of splittedShaderCode) {
 			if (obj.shaderStage === 'vertex') {
 				const attributeMatch = row.match(/^(?![\/])[\t ]*(attribute|in)[\t ]+.+;/);
 				if (attributeMatch) {


### PR DESCRIPTION
In this PR, all code related to Shaderity.reflect has been moved to the Reflection class. We are upgrading the version because of a breaking change.

**Breaking Change**
Shaderity.addAttributeSemanticsMap has been removed. Use Reflection.addAttributeSemanticsMap instead. 