### PR TITLE
refactor: move shader transform feature to ShaderTransformer.ts

### DIFF
--- a/src/main/ShaderTransformer.ts
+++ b/src/main/ShaderTransformer.ts
@@ -10,7 +10,7 @@ export default class ShaderTransformer {
 	}
 
 	static _transformToGLSLES3(splittedShaderCode: string[], isFragmentShader: boolean) {
-		this.__convertAttribute(splittedShaderCode);
+		this.__convertAttribute(splittedShaderCode, isFragmentShader);
 		this.__convertVarying(splittedShaderCode, isFragmentShader);
 		this.__convertTexture2D(splittedShaderCode);
 		this.__convertTextureCube(splittedShaderCode);
@@ -137,7 +137,11 @@ export default class ShaderTransformer {
 		return uniformSamplerMap;
 	}
 
-	private static __convertAttribute(splittedShaderCode: string[]) {
+	private static __convertAttribute(splittedShaderCode: string[], isFragmentShader: boolean) {
+		if (isFragmentShader) {
+			return;
+		}
+
 		const inReg = /^(?![\/])[\t ]*attribute[\t ]+/g;
 		const inAsES3 = 'in ';
 

--- a/src/main/ShaderTransformer.ts
+++ b/src/main/ShaderTransformer.ts
@@ -1,0 +1,187 @@
+export default class ShaderTransformer {
+	static _transformToGLSLES1(splittedShaderCode: string[], isFragmentShader: boolean) {
+		this.__convertIn(splittedShaderCode, isFragmentShader);
+		this.__convertOut(splittedShaderCode);
+		this.__removeLayout(splittedShaderCode);
+		this.__convertTextureFunctionToES1(splittedShaderCode);
+		const transformedSplittedShaderCode = splittedShaderCode;
+
+		return transformedSplittedShaderCode;
+	}
+
+	static _transformToGLSLES3(splittedShaderCode: string[], isFragmentShader: boolean) {
+		this.__convertAttribute(splittedShaderCode);
+		this.__convertVarying(splittedShaderCode, isFragmentShader);
+		this.__convertTexture2D(splittedShaderCode);
+		this.__convertTextureCube(splittedShaderCode);
+		this.__convertTexture2DProd(splittedShaderCode);
+		const transformedSplittedShaderCode = splittedShaderCode;
+
+		return transformedSplittedShaderCode;
+	}
+
+	static _transformTo(version: string, splittedShaderCode: string[], isFragmentShader: boolean) {
+		if (version.match(/webgl2|es3/i)) {
+			return this._transformToGLSLES3(splittedShaderCode, isFragmentShader);
+		} else if (version.match(/webgl1|es1/i)) {
+			return this._transformToGLSLES1(splittedShaderCode, isFragmentShader);
+		} else {
+			console.error('Invalid Version')
+			return splittedShaderCode;
+		}
+	}
+
+	private static __convertIn(inout_splittedSource: string[], isFragmentShader: boolean) {
+		const inReg = /^(?![\/])[\t ]*in[\t ]+(\w+[\t ]*\w+[\t ]*;)/;
+
+		// inAsES1 is used as the second argument to the String.prototype.replace method.
+		let inAsES1;
+		if (isFragmentShader) {
+			inAsES1 = function (match: string, p1: string) {
+				return 'varying ' + p1;
+			}
+		} else {
+			inAsES1 = function (match: string, p1: string) {
+				return 'attribute ' + p1;
+			}
+		}
+
+		this.__replaceRow(inout_splittedSource, inReg, inAsES1);
+	}
+
+
+	private static __convertOut(inout_splittedSource: string[]) {
+		const inReg = /^(?![\/])[\t ]*out[\t ]+(\w+[\t ]*\w+[\t ]*;)/;
+		const inAsES1 = function (match: string, p1: string) {
+			return 'varying ' + p1;
+		}
+
+		this.__replaceRow(inout_splittedSource, inReg, inAsES1);
+	}
+
+	private static __removeLayout(inout_splittedSource: string[]) {
+		const inReg = /^(?![\/])[\t ]*layout[\t ]*\([\t ]*location[\t ]*\=[\t ]*\d[\t ]*\)[\t ]+/g;
+		this.__replaceRow(inout_splittedSource, inReg, '');
+	}
+
+	private static __convertTextureFunctionToES1(inout_splittedSource: string[]) {
+		const sbl = this.__regSymbols();
+
+		for (let i = 0; i < inout_splittedSource.length; i++) {
+			const row = inout_splittedSource[i];
+
+			let reg = new RegExp(`(${sbl}+)(textureProj)(${sbl}+)`, 'g');
+			let match = row.match(/textureProj[\t ]*\([\t ]*(\w+),/);
+			if (match) {
+				const name = match[1];
+				const uniformSamplerMap = this.__createUniformSamplerMap(inout_splittedSource, i);
+				const samplerType = uniformSamplerMap.get(name);
+				if (samplerType != null) {
+					let textureFunc: string;
+					switch (samplerType) {
+						case 'sampler2D':
+							textureFunc = 'texture2DProj';
+							break;
+						case 'sampler3D':
+							textureFunc = 'texture3DProj';
+							break;
+						default:
+							textureFunc = '';
+							console.log('not found');
+					}
+					inout_splittedSource[i] = inout_splittedSource[i].replace(reg, '$1' + textureFunc + '$3');
+				}
+				continue;
+			}
+
+			reg = new RegExp(`(${sbl}+)(texture)(${sbl}+)`, 'g');
+			match = row.match(/texture[\t ]*\([\t ]*(\w+),/);
+			if (match) {
+				const name = match[1];
+				const uniformSamplerMap = this.__createUniformSamplerMap(inout_splittedSource, i);
+				const samplerType = uniformSamplerMap.get(name);
+				if (samplerType != null) {
+					let textureFunc: string;
+					switch (samplerType) {
+						case 'sampler2D':
+							textureFunc = 'texture2D';
+							break;
+						case 'sampler3D':
+							textureFunc = 'texture3D';
+							break;
+						case 'samplerCube':
+							textureFunc = 'textureCube';
+							break;
+						default:
+							textureFunc = '';
+							console.log('not found');
+					}
+					inout_splittedSource[i] = inout_splittedSource[i].replace(reg, '$1' + textureFunc + '$3');
+				}
+			}
+		}
+	}
+
+	private static __createUniformSamplerMap(inout_splittedSource: string[], row_i: number) {
+		const uniformSamplerMap = new Map();
+
+		for (let i = 0; i < row_i; i++) {
+			const row = inout_splittedSource[i];
+			const match = row.match(/^(?![\/])[\t ]*\w*[\t ]*(sampler\w+)[\t ]+(\w+)/);
+			if (match) {
+				const samplerType = match[1];
+				const name = match[2];
+				uniformSamplerMap.set(name, samplerType);
+			}
+		}
+		return uniformSamplerMap;
+	}
+
+	private static __convertAttribute(inout_splittedSource: string[]) {
+		const inReg = /^(?![\/])[\t ]*attribute[\t ]+/g;
+		const inAsES3 = 'in ';
+
+		this.__replaceRow(inout_splittedSource, inReg, inAsES3);
+	}
+
+	private static __convertVarying(inout_splittedSource: string[], isFragmentShader: boolean) {
+		const inReg = /^(?![\/])[\t ]*varying[\t ]+/g;
+		const inAsES3 = isFragmentShader ? 'in ' : 'out ';
+
+		this.__replaceRow(inout_splittedSource, inReg, inAsES3);
+	}
+
+	private static __convertTextureCube(inout_splittedSource: string[]) {
+		const sbl = this.__regSymbols();
+		const reg = new RegExp(`(${sbl}+)(textureCube)(${sbl}+)`, 'g');
+		const inAsES3 = 'texture';
+
+		this.__replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
+	}
+
+	private static __convertTexture2D(inout_splittedSource: string[]) {
+		const sbl = this.__regSymbols();
+		const reg = new RegExp(`(${sbl}+)(texture2D)(${sbl}+)`, 'g');
+		const inAsES3 = 'texture';
+
+		this.__replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
+	}
+
+	private static __convertTexture2DProd(inout_splittedSource: string[]) {
+		const sbl = this.__regSymbols();
+		const reg = new RegExp(`(${sbl}+)(texture2DProj)(${sbl}+)`, 'g');
+		const inAsES3 = 'textureProj';
+
+		this.__replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
+	}
+
+	private static __regSymbols() {
+		return `[!"#$%&'()\*\+\-\.,\/:;<=>?@\[\\\]^` + '`{|}~\t\n ]';
+	}
+
+	private static __replaceRow(inout_splittedSource: string[], inReg: RegExp, inAsES1: any) {
+		for (let i = 0; i < inout_splittedSource.length; i++) {
+			inout_splittedSource[i] = inout_splittedSource[i].replace(inReg, inAsES1);
+		}
+	}
+}

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -54,7 +54,7 @@ export default class Shaderity {
 	}
 
 
-	private _convertOut(obj: ShaderityObject, inout_splitedSource: string[]) {
+	private _convertOut(inout_splitedSource: string[]) {
 		const inReg = /^(?![\/])[\t ]*out[\t ]+(\w+[\t ]*\w+[\t ]*;)/;
 		let inAsES1 = function (match: string, p1: string) {
 			return 'varying ' + p1;
@@ -80,7 +80,7 @@ export default class Shaderity {
 		return uniformSamplerMap;
 	}
 
-	private _convertAttribute(obj: ShaderityObject, inout_splitedSource: string[]) {
+	private _convertAttribute(inout_splitedSource: string[]) {
 		const inReg = /^(?![\/])[\t ]*attribute[\t ]+/g;
 		let inAsES3 = 'in ';
 
@@ -102,7 +102,7 @@ export default class Shaderity {
 		return inout_splitedSource;
 	}
 
-	private _removeLayout(obj: ShaderityObject, inout_splitedSource: string[]) {
+	private _removeLayout(inout_splitedSource: string[]) {
 		const inReg = /^(?![\/])[\t ]*layout[\t ]*\([\t ]*location[\t ]*\=[\t ]*\d[\t ]*\)[\t ]+/g;
 		this._replaceRow(inout_splitedSource, inReg, '');
 
@@ -113,7 +113,7 @@ export default class Shaderity {
 		return `[!"#$%&'()\*\+\-\.,\/:;<=>?@\[\\\]^` + '`{|}~\t\n ]';
 	}
 
-	private _convertTexture2D(obj: ShaderityObject, inout_splitedSource: string[]) {
+	private _convertTexture2D(inout_splitedSource: string[]) {
 		const sbl = this._regSymbols();
 		const reg = new RegExp(`(${sbl}+)(texture2D)(${sbl}+)`, 'g');
 		let inAsES3 = 'texture';
@@ -123,7 +123,7 @@ export default class Shaderity {
 		return inout_splitedSource;
 	}
 
-	private _convertTextureCube(obj: ShaderityObject, inout_splitedSource: string[]) {
+	private _convertTextureCube(inout_splitedSource: string[]) {
 		const sbl = this._regSymbols();
 		const reg = new RegExp(`(${sbl}+)(textureCube)(${sbl}+)`, 'g');
 		let inAsES3 = 'texture';
@@ -133,7 +133,7 @@ export default class Shaderity {
 		return inout_splitedSource;
 	}
 
-	private _convertTexture2DProd(obj: ShaderityObject, inout_splitedSource: string[]) {
+	private _convertTexture2DProd(inout_splitedSource: string[]) {
 		const sbl = this._regSymbols();
 		const reg = new RegExp(`(${sbl}+)(texture2DProj)(${sbl}+)`, 'g');
 		let inAsES3 = 'textureProj';
@@ -205,8 +205,8 @@ export default class Shaderity {
 		let splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		this._convertIn(obj, splittedShaderCode);
-		this._convertOut(obj, splittedShaderCode);
-		this._removeLayout(obj, splittedShaderCode);
+		this._convertOut(splittedShaderCode);
+		this._removeLayout(splittedShaderCode);
 
 		splittedShaderCode = this._convertTextureFunctionToES1(splittedShaderCode);
 
@@ -220,11 +220,11 @@ export default class Shaderity {
 
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
-		this._convertAttribute(obj, splittedShaderCode);
+		this._convertAttribute(splittedShaderCode);
 		this._convertVarying(obj, splittedShaderCode);
-		this._convertTexture2D(obj, splittedShaderCode);
-		this._convertTextureCube(obj, splittedShaderCode);
-		this._convertTexture2DProd(obj, splittedShaderCode);
+		this._convertTexture2D(splittedShaderCode);
+		this._convertTextureCube(splittedShaderCode);
+		this._convertTexture2DProd(splittedShaderCode);
 
 		copy.code = this._joinSplitedRow(splittedShaderCode);
 
@@ -298,9 +298,5 @@ export default class Shaderity {
 
 		const reflection = new Reflection(splittedShaderCode, shaderStage);
 		return reflection;
-	}
-
-	private _defineGLSLES3() {
-
 	}
 }

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -184,8 +184,6 @@ export default class Shaderity {
 	}
 
 	transformToGLSLES1(obj: ShaderityObject) {
-		const copy = this.copyShaderityObject(obj);
-
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const isFragmentShader = this.isFragmentShader(obj);
@@ -193,16 +191,17 @@ export default class Shaderity {
 		this._convertOut(splittedShaderCode);
 		this._removeLayout(splittedShaderCode);
 		this._convertTextureFunctionToES1(splittedShaderCode);
+		const resultCode = this._joinSplittedRow(splittedShaderCode);
 
+		const resultObj: ShaderityObject = {
+			code: resultCode,
+			shaderStage: obj.shaderStage,
+		};
 
-		copy.code = this._joinSplittedRow(splittedShaderCode);
-
-		return copy;
+		return resultObj;
 	}
 
 	transformToGLSLES3(obj: ShaderityObject) {
-		const copy = this.copyShaderityObject(obj);
-
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const isFragmentShader = this.isFragmentShader(obj);
@@ -211,10 +210,14 @@ export default class Shaderity {
 		this._convertTexture2D(splittedShaderCode);
 		this._convertTextureCube(splittedShaderCode);
 		this._convertTexture2DProd(splittedShaderCode);
+		const resultCode = this._joinSplittedRow(splittedShaderCode);
 
-		copy.code = this._joinSplittedRow(splittedShaderCode);
+		const resultObj: ShaderityObject = {
+			code: resultCode,
+			shaderStage: obj.shaderStage,
+		};
 
-		return copy;
+		return resultObj;
 	}
 
 	transformTo(version: string, obj: ShaderityObject) {

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -31,13 +31,13 @@ export default class Shaderity {
 		return this.isFragmentShader(obj);
 	}
 
-	private _replaceRow(inout_splitedSource: string[], inReg: RegExp, inAsES1: any) {
-		for (let i = 0; i < inout_splitedSource.length; i++) {
-			inout_splitedSource[i] = inout_splitedSource[i].replace(inReg, inAsES1);
+	private _replaceRow(inout_splittedSource: string[], inReg: RegExp, inAsES1: any) {
+		for (let i = 0; i < inout_splittedSource.length; i++) {
+			inout_splittedSource[i] = inout_splittedSource[i].replace(inReg, inAsES1);
 		}
 	}
 
-	private _convertIn(inout_splitedSource: string[], isFragmentShader: boolean) {
+	private _convertIn(inout_splittedSource: string[], isFragmentShader: boolean) {
 		const inReg = /^(?![\/])[\t ]*in[\t ]+(\w+[\t ]*\w+[\t ]*;)/;
 		let inAsES1;
 		if (isFragmentShader) {
@@ -50,24 +50,24 @@ export default class Shaderity {
 			}
 		}
 
-		this._replaceRow(inout_splitedSource, inReg, inAsES1);
+		this._replaceRow(inout_splittedSource, inReg, inAsES1);
 	}
 
 
-	private _convertOut(inout_splitedSource: string[]) {
+	private _convertOut(inout_splittedSource: string[]) {
 		const inReg = /^(?![\/])[\t ]*out[\t ]+(\w+[\t ]*\w+[\t ]*;)/;
 		let inAsES1 = function (match: string, p1: string) {
 			return 'varying ' + p1;
 		}
 
-		this._replaceRow(inout_splitedSource, inReg, inAsES1);
+		this._replaceRow(inout_splittedSource, inReg, inAsES1);
 	}
 
-	private _createUniformSamplerMap(inout_splitedSource: string[], row_i: number) {
+	private _createUniformSamplerMap(inout_splittedSource: string[], row_i: number) {
 		const uniformSamplerMap = new Map();
 
 		for (let i = 0; i < row_i; i++) {
-			const row = inout_splitedSource[i];
+			const row = inout_splittedSource[i];
 			const match = row.match(/^(?![\/])[\t ]*\w*[\t ]*(sampler\w+)[\t ]+(\w+)/);
 			if (match) {
 				const samplerType = match[1];
@@ -78,14 +78,14 @@ export default class Shaderity {
 		return uniformSamplerMap;
 	}
 
-	private _convertAttribute(inout_splitedSource: string[]) {
+	private _convertAttribute(inout_splittedSource: string[]) {
 		const inReg = /^(?![\/])[\t ]*attribute[\t ]+/g;
 		let inAsES3 = 'in ';
 
-		this._replaceRow(inout_splitedSource, inReg, inAsES3);
+		this._replaceRow(inout_splittedSource, inReg, inAsES3);
 	}
 
-	private _convertVarying(inout_splitedSource: string[], isFragmentShader: boolean) {
+	private _convertVarying(inout_splittedSource: string[], isFragmentShader: boolean) {
 		const inReg = /^(?![\/])[\t ]*varying[\t ]+/g;
 		let inAsES3 = 'out ';
 
@@ -93,40 +93,40 @@ export default class Shaderity {
 			inAsES3 = 'in ';
 		}
 
-		this._replaceRow(inout_splitedSource, inReg, inAsES3);
+		this._replaceRow(inout_splittedSource, inReg, inAsES3);
 	}
 
-	private _removeLayout(inout_splitedSource: string[]) {
+	private _removeLayout(inout_splittedSource: string[]) {
 		const inReg = /^(?![\/])[\t ]*layout[\t ]*\([\t ]*location[\t ]*\=[\t ]*\d[\t ]*\)[\t ]+/g;
-		this._replaceRow(inout_splitedSource, inReg, '');
+		this._replaceRow(inout_splittedSource, inReg, '');
 	}
 
 	private _regSymbols() {
 		return `[!"#$%&'()\*\+\-\.,\/:;<=>?@\[\\\]^` + '`{|}~\t\n ]';
 	}
 
-	private _convertTexture2D(inout_splitedSource: string[]) {
+	private _convertTexture2D(inout_splittedSource: string[]) {
 		const sbl = this._regSymbols();
 		const reg = new RegExp(`(${sbl}+)(texture2D)(${sbl}+)`, 'g');
 		let inAsES3 = 'texture';
 
-		this._replaceRow(inout_splitedSource, reg, '$1' + inAsES3 + '$3');
+		this._replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
 	}
 
-	private _convertTextureCube(inout_splitedSource: string[]) {
+	private _convertTextureCube(inout_splittedSource: string[]) {
 		const sbl = this._regSymbols();
 		const reg = new RegExp(`(${sbl}+)(textureCube)(${sbl}+)`, 'g');
 		let inAsES3 = 'texture';
 
-		this._replaceRow(inout_splitedSource, reg, '$1' + inAsES3 + '$3');
+		this._replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
 	}
 
-	private _convertTexture2DProd(inout_splitedSource: string[]) {
+	private _convertTexture2DProd(inout_splittedSource: string[]) {
 		const sbl = this._regSymbols();
 		const reg = new RegExp(`(${sbl}+)(texture2DProj)(${sbl}+)`, 'g');
 		let inAsES3 = 'textureProj';
 
-		this._replaceRow(inout_splitedSource, reg, '$1' + inAsES3 + '$3');
+		this._replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
 	}
 
 
@@ -139,17 +139,17 @@ export default class Shaderity {
 		return copiedObj;
 	}
 
-	_convertTextureFunctionToES1(inout_splitedSource: string[]) {
+	_convertTextureFunctionToES1(inout_splittedSource: string[]) {
 		const sbl = this._regSymbols();
 
-		for (let i = 0; i < inout_splitedSource.length; i++) {
-			const row = inout_splitedSource[i];
+		for (let i = 0; i < inout_splittedSource.length; i++) {
+			const row = inout_splittedSource[i];
 
 			let reg = new RegExp(`(${sbl}+)(textureProj)(${sbl}+)`, 'g');
 			let match = row.match(/textureProj[\t ]*\([\t ]*(\w+),/);
 			if (match) {
 				const name = match[1];
-				const uniformSamplerMap = this._createUniformSamplerMap(inout_splitedSource, i);
+				const uniformSamplerMap = this._createUniformSamplerMap(inout_splittedSource, i);
 				const samplerType = uniformSamplerMap.get(name);
 				if (samplerType != null) {
 					let textureFunc = '';
@@ -158,7 +158,7 @@ export default class Shaderity {
 						case 'sampler3D': textureFunc = 'texture3DProj'; break;
 						default: console.log('not found');
 					}
-					inout_splitedSource[i] = inout_splitedSource[i].replace(reg, '$1' + textureFunc + '$3');
+					inout_splittedSource[i] = inout_splittedSource[i].replace(reg, '$1' + textureFunc + '$3');
 				}
 				continue;
 			}
@@ -167,7 +167,7 @@ export default class Shaderity {
 			match = row.match(/texture[\t ]*\([\t ]*(\w+),/);
 			if (match) {
 				const name = match[1];
-				const uniformSamplerMap = this._createUniformSamplerMap(inout_splitedSource, i);
+				const uniformSamplerMap = this._createUniformSamplerMap(inout_splittedSource, i);
 				const samplerType = uniformSamplerMap.get(name);
 				if (samplerType != null) {
 					let textureFunc = '';
@@ -177,7 +177,7 @@ export default class Shaderity {
 						case 'samplerCube': textureFunc = 'textureCube'; break;
 						default: console.log('not found');
 					}
-					inout_splitedSource[i] = inout_splitedSource[i].replace(reg, '$1' + textureFunc + '$3');
+					inout_splittedSource[i] = inout_splittedSource[i].replace(reg, '$1' + textureFunc + '$3');
 				}
 			}
 		}
@@ -195,7 +195,7 @@ export default class Shaderity {
 		this._convertTextureFunctionToES1(splittedShaderCode);
 
 
-		copy.code = this._joinSplitedRow(splittedShaderCode);
+		copy.code = this._joinSplittedRow(splittedShaderCode);
 
 		return copy;
 	}
@@ -212,7 +212,7 @@ export default class Shaderity {
 		this._convertTextureCube(splittedShaderCode);
 		this._convertTexture2DProd(splittedShaderCode);
 
-		copy.code = this._joinSplitedRow(splittedShaderCode);
+		copy.code = this._joinSplittedRow(splittedShaderCode);
 
 		return copy;
 	}
@@ -232,8 +232,8 @@ export default class Shaderity {
 		return source.split(/\r\n|\n/);
 	}
 
-	private _joinSplitedRow(splitedRow: string[]) {
-		return splitedRow.join('\n');
+	private _joinSplittedRow(splittedRow: string[]) {
+		return splittedRow.join('\n');
 	}
 
 	/**
@@ -264,7 +264,7 @@ export default class Shaderity {
 
 		splittedShaderCode.unshift(`#define ${defStr}`);
 
-		copy.code = this._joinSplitedRow(splittedShaderCode);
+		copy.code = this._joinSplittedRow(splittedShaderCode);
 
 		return copy;
 	}

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -51,8 +51,6 @@ export default class Shaderity {
 		}
 
 		this._replaceRow(inout_splitedSource, inReg, inAsES1);
-
-		return inout_splitedSource;
 	}
 
 
@@ -63,8 +61,6 @@ export default class Shaderity {
 		}
 
 		this._replaceRow(inout_splitedSource, inReg, inAsES1);
-
-		return inout_splitedSource;
 	}
 
 	private _createUniformSamplerMap(inout_splitedSource: string[], row_i: number) {
@@ -87,8 +83,6 @@ export default class Shaderity {
 		let inAsES3 = 'in ';
 
 		this._replaceRow(inout_splitedSource, inReg, inAsES3);
-
-		return inout_splitedSource;
 	}
 
 	private _convertVarying(inout_splitedSource: string[], isFragmentShader: boolean) {
@@ -100,15 +94,11 @@ export default class Shaderity {
 		}
 
 		this._replaceRow(inout_splitedSource, inReg, inAsES3);
-
-		return inout_splitedSource;
 	}
 
 	private _removeLayout(inout_splitedSource: string[]) {
 		const inReg = /^(?![\/])[\t ]*layout[\t ]*\([\t ]*location[\t ]*\=[\t ]*\d[\t ]*\)[\t ]+/g;
 		this._replaceRow(inout_splitedSource, inReg, '');
-
-		return inout_splitedSource;
 	}
 
 	private _regSymbols() {
@@ -121,8 +111,6 @@ export default class Shaderity {
 		let inAsES3 = 'texture';
 
 		this._replaceRow(inout_splitedSource, reg, '$1' + inAsES3 + '$3');
-
-		return inout_splitedSource;
 	}
 
 	private _convertTextureCube(inout_splitedSource: string[]) {
@@ -131,8 +119,6 @@ export default class Shaderity {
 		let inAsES3 = 'texture';
 
 		this._replaceRow(inout_splitedSource, reg, '$1' + inAsES3 + '$3');
-
-		return inout_splitedSource;
 	}
 
 	private _convertTexture2DProd(inout_splitedSource: string[]) {
@@ -141,8 +127,6 @@ export default class Shaderity {
 		let inAsES3 = 'textureProj';
 
 		this._replaceRow(inout_splitedSource, reg, '$1' + inAsES3 + '$3');
-
-		return inout_splitedSource;
 	}
 
 
@@ -197,21 +181,19 @@ export default class Shaderity {
 				}
 			}
 		}
-
-		return inout_splitedSource;
 	}
 
 	transformToGLSLES1(obj: ShaderityObject) {
 		const copy = this.copyShaderityObject(obj);
 
-		let splittedShaderCode = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const isFragmentShader = this.isFragmentShader(obj);
 		this._convertIn(splittedShaderCode, isFragmentShader);
 		this._convertOut(splittedShaderCode);
 		this._removeLayout(splittedShaderCode);
+		this._convertTextureFunctionToES1(splittedShaderCode);
 
-		splittedShaderCode = this._convertTextureFunctionToES1(splittedShaderCode);
 
 		copy.code = this._joinSplitedRow(splittedShaderCode);
 

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -37,14 +37,16 @@ export default class Shaderity {
 		}
 	}
 
-	private _convertIn(obj: ShaderityObject, inout_splitedSource: string[]) {
+	private _convertIn(inout_splitedSource: string[], isFragmentShader: boolean) {
 		const inReg = /^(?![\/])[\t ]*in[\t ]+(\w+[\t ]*\w+[\t ]*;)/;
-		let inAsES1 = function (match: string, p1: string) {
-			return 'attribute ' + p1;
-		}
-		if (this.isFragmentShader(obj)) {
+		let inAsES1;
+		if (isFragmentShader) {
 			inAsES1 = function (match: string, p1: string) {
 				return 'varying ' + p1;
+			}
+		} else {
+			inAsES1 = function (match: string, p1: string) {
+				return 'attribute ' + p1;
 			}
 		}
 
@@ -89,11 +91,11 @@ export default class Shaderity {
 		return inout_splitedSource;
 	}
 
-	private _convertVarying(obj: ShaderityObject, inout_splitedSource: string[]) {
+	private _convertVarying(inout_splitedSource: string[], isFragmentShader: boolean) {
 		const inReg = /^(?![\/])[\t ]*varying[\t ]+/g;
 		let inAsES3 = 'out ';
 
-		if (this.isFragmentShader(obj)) {
+		if (isFragmentShader) {
 			inAsES3 = 'in ';
 		}
 
@@ -204,7 +206,8 @@ export default class Shaderity {
 
 		let splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
-		this._convertIn(obj, splittedShaderCode);
+		const isFragmentShader = this.isFragmentShader(obj);
+		this._convertIn(splittedShaderCode, isFragmentShader);
 		this._convertOut(splittedShaderCode);
 		this._removeLayout(splittedShaderCode);
 
@@ -220,8 +223,9 @@ export default class Shaderity {
 
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
+		const isFragmentShader = this.isFragmentShader(obj);
 		this._convertAttribute(splittedShaderCode);
-		this._convertVarying(obj, splittedShaderCode);
+		this._convertVarying(splittedShaderCode, isFragmentShader);
 		this._convertTexture2D(splittedShaderCode);
 		this._convertTextureCube(splittedShaderCode);
 		this._convertTexture2DProd(splittedShaderCode);

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -1,5 +1,6 @@
 import Reflection from './Reflection';
 import {ShaderityObject} from '../types/type';
+import ShaderTransformer from './ShaderTransformer';
 
 export default class Shaderity {
 	private static __instance: Shaderity;
@@ -31,105 +32,6 @@ export default class Shaderity {
 		return this.isFragmentShader(obj);
 	}
 
-	private _replaceRow(inout_splittedSource: string[], inReg: RegExp, inAsES1: any) {
-		for (let i = 0; i < inout_splittedSource.length; i++) {
-			inout_splittedSource[i] = inout_splittedSource[i].replace(inReg, inAsES1);
-		}
-	}
-
-	private _convertIn(inout_splittedSource: string[], isFragmentShader: boolean) {
-		const inReg = /^(?![\/])[\t ]*in[\t ]+(\w+[\t ]*\w+[\t ]*;)/;
-		let inAsES1;
-		if (isFragmentShader) {
-			inAsES1 = function (match: string, p1: string) {
-				return 'varying ' + p1;
-			}
-		} else {
-			inAsES1 = function (match: string, p1: string) {
-				return 'attribute ' + p1;
-			}
-		}
-
-		this._replaceRow(inout_splittedSource, inReg, inAsES1);
-	}
-
-
-	private _convertOut(inout_splittedSource: string[]) {
-		const inReg = /^(?![\/])[\t ]*out[\t ]+(\w+[\t ]*\w+[\t ]*;)/;
-		let inAsES1 = function (match: string, p1: string) {
-			return 'varying ' + p1;
-		}
-
-		this._replaceRow(inout_splittedSource, inReg, inAsES1);
-	}
-
-	private _createUniformSamplerMap(inout_splittedSource: string[], row_i: number) {
-		const uniformSamplerMap = new Map();
-
-		for (let i = 0; i < row_i; i++) {
-			const row = inout_splittedSource[i];
-			const match = row.match(/^(?![\/])[\t ]*\w*[\t ]*(sampler\w+)[\t ]+(\w+)/);
-			if (match) {
-				const samplerType = match[1];
-				const name = match[2];
-				uniformSamplerMap.set(name, samplerType);
-			}
-		}
-		return uniformSamplerMap;
-	}
-
-	private _convertAttribute(inout_splittedSource: string[]) {
-		const inReg = /^(?![\/])[\t ]*attribute[\t ]+/g;
-		let inAsES3 = 'in ';
-
-		this._replaceRow(inout_splittedSource, inReg, inAsES3);
-	}
-
-	private _convertVarying(inout_splittedSource: string[], isFragmentShader: boolean) {
-		const inReg = /^(?![\/])[\t ]*varying[\t ]+/g;
-		let inAsES3 = 'out ';
-
-		if (isFragmentShader) {
-			inAsES3 = 'in ';
-		}
-
-		this._replaceRow(inout_splittedSource, inReg, inAsES3);
-	}
-
-	private _removeLayout(inout_splittedSource: string[]) {
-		const inReg = /^(?![\/])[\t ]*layout[\t ]*\([\t ]*location[\t ]*\=[\t ]*\d[\t ]*\)[\t ]+/g;
-		this._replaceRow(inout_splittedSource, inReg, '');
-	}
-
-	private _regSymbols() {
-		return `[!"#$%&'()\*\+\-\.,\/:;<=>?@\[\\\]^` + '`{|}~\t\n ]';
-	}
-
-	private _convertTexture2D(inout_splittedSource: string[]) {
-		const sbl = this._regSymbols();
-		const reg = new RegExp(`(${sbl}+)(texture2D)(${sbl}+)`, 'g');
-		let inAsES3 = 'texture';
-
-		this._replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
-	}
-
-	private _convertTextureCube(inout_splittedSource: string[]) {
-		const sbl = this._regSymbols();
-		const reg = new RegExp(`(${sbl}+)(textureCube)(${sbl}+)`, 'g');
-		let inAsES3 = 'texture';
-
-		this._replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
-	}
-
-	private _convertTexture2DProd(inout_splittedSource: string[]) {
-		const sbl = this._regSymbols();
-		const reg = new RegExp(`(${sbl}+)(texture2DProj)(${sbl}+)`, 'g');
-		let inAsES3 = 'textureProj';
-
-		this._replaceRow(inout_splittedSource, reg, '$1' + inAsES3 + '$3');
-	}
-
-
 	copyShaderityObject(obj: ShaderityObject) {
 		const copiedObj: ShaderityObject = {
 			code: obj.code,
@@ -139,59 +41,13 @@ export default class Shaderity {
 		return copiedObj;
 	}
 
-	_convertTextureFunctionToES1(inout_splittedSource: string[]) {
-		const sbl = this._regSymbols();
-
-		for (let i = 0; i < inout_splittedSource.length; i++) {
-			const row = inout_splittedSource[i];
-
-			let reg = new RegExp(`(${sbl}+)(textureProj)(${sbl}+)`, 'g');
-			let match = row.match(/textureProj[\t ]*\([\t ]*(\w+),/);
-			if (match) {
-				const name = match[1];
-				const uniformSamplerMap = this._createUniformSamplerMap(inout_splittedSource, i);
-				const samplerType = uniformSamplerMap.get(name);
-				if (samplerType != null) {
-					let textureFunc = '';
-					switch (samplerType) {
-						case 'sampler2D': textureFunc = 'texture2DProj'; break;
-						case 'sampler3D': textureFunc = 'texture3DProj'; break;
-						default: console.log('not found');
-					}
-					inout_splittedSource[i] = inout_splittedSource[i].replace(reg, '$1' + textureFunc + '$3');
-				}
-				continue;
-			}
-
-			reg = new RegExp(`(${sbl}+)(texture)(${sbl}+)`, 'g');
-			match = row.match(/texture[\t ]*\([\t ]*(\w+),/);
-			if (match) {
-				const name = match[1];
-				const uniformSamplerMap = this._createUniformSamplerMap(inout_splittedSource, i);
-				const samplerType = uniformSamplerMap.get(name);
-				if (samplerType != null) {
-					let textureFunc = '';
-					switch (samplerType) {
-						case 'sampler2D': textureFunc = 'texture2D'; break;
-						case 'sampler3D': textureFunc = 'texture3D'; break;
-						case 'samplerCube': textureFunc = 'textureCube'; break;
-						default: console.log('not found');
-					}
-					inout_splittedSource[i] = inout_splittedSource[i].replace(reg, '$1' + textureFunc + '$3');
-				}
-			}
-		}
-	}
-
 	transformToGLSLES1(obj: ShaderityObject) {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
-
 		const isFragmentShader = this.isFragmentShader(obj);
-		this._convertIn(splittedShaderCode, isFragmentShader);
-		this._convertOut(splittedShaderCode);
-		this._removeLayout(splittedShaderCode);
-		this._convertTextureFunctionToES1(splittedShaderCode);
-		const resultCode = this._joinSplittedRow(splittedShaderCode);
+
+		const transformedSplittedShaderCode
+			= ShaderTransformer._transformToGLSLES1(splittedShaderCode, isFragmentShader);
+		const resultCode = this._joinSplittedRow(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
 			code: resultCode,
@@ -205,12 +61,9 @@ export default class Shaderity {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const isFragmentShader = this.isFragmentShader(obj);
-		this._convertAttribute(splittedShaderCode);
-		this._convertVarying(splittedShaderCode, isFragmentShader);
-		this._convertTexture2D(splittedShaderCode);
-		this._convertTextureCube(splittedShaderCode);
-		this._convertTexture2DProd(splittedShaderCode);
-		const resultCode = this._joinSplittedRow(splittedShaderCode);
+		const transformedSplittedShaderCode
+			= ShaderTransformer._transformToGLSLES3(splittedShaderCode, isFragmentShader);
+		const resultCode = this._joinSplittedRow(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
 			code: resultCode,
@@ -221,14 +74,19 @@ export default class Shaderity {
 	}
 
 	transformTo(version: string, obj: ShaderityObject) {
-		if (version.match(/webgl2|es3/i)) {
-			return this.transformToGLSLES3(obj);
-		} else if (version.match(/webgl1|es1/i)) {
-			return this.transformToGLSLES1(obj);
-		} else {
-			console.error('Invalid Version')
-			return obj;
-		}
+		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
+
+		const isFragmentShader = this.isFragmentShader(obj);
+		const transformedSplittedShaderCode
+			= ShaderTransformer._transformTo(version, splittedShaderCode, isFragmentShader);
+		const resultCode = this._joinSplittedRow(transformedSplittedShaderCode);
+
+		const resultObj: ShaderityObject = {
+			code: resultCode,
+			shaderStage: obj.shaderStage,
+		};
+
+		return resultObj;
 	}
 
 	private _splitByLineFeedCode(source: string) {


### PR DESCRIPTION
In this PR, all code related to Shaderity.transformToGLSLES1, Shaderity.transformToGLSLES3 and Shaderity.transformTo methods have been moved to the ShaderTransformer class.