### PR TITLE
feat: embed the version information in the first line of the shader

### DIFF
--- a/assets/texture_es1.frag
+++ b/assets/texture_es1.frag
@@ -1,3 +1,6 @@
+// texture_es1.frag
+#version 100
+
 varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D u_texture;

--- a/assets/texture_es3.frag
+++ b/assets/texture_es3.frag
@@ -1,3 +1,5 @@
+#version 300 es
+
 in vec2 v_texcoord;
 in vec3 v_texcoord3;
 uniform sampler2D u_texture;

--- a/src/main/ShaderTransformer.ts
+++ b/src/main/ShaderTransformer.ts
@@ -47,6 +47,15 @@ export default class ShaderTransformer {
 		}
 	}
 
+	/**
+	 * @private
+	 * If the first line contains version information, overwrite the first line with '#version 100'.
+	 * If not, add '#version 100' to the first line.
+	 *
+	 * Note: If the first line is commented out and the version information is written in the second or later line,
+	 * the appropriate version information will be added to the first line and the user-defined version information
+	 * in the second or later line will be removed.
+	 */
 	private static __convertOrInsertVersionGLSLES1(splittedShaderCode: string[]) {
 		const inReg = /^(?![\/])[\t ]*#[\t ]*version[\t ]+.*/;
 		this.__removeFirstMatchingLine(splittedShaderCode, inReg);
@@ -54,6 +63,17 @@ export default class ShaderTransformer {
 		splittedShaderCode.unshift('#version 100');
 	}
 
+	/**
+	 * @private
+	 * If the first line contains version information, overwrite the first line with '#version 300 es'.
+	 * If not, add '#version 300 es' to the first line.
+	 * In both cases, '#define GLSL_ES3' will be inserted in the second line.
+	 * Use the '#define GLSL_ES3' directive if you want to write a shader code that will only run in the case of webgl2.
+	 *
+   * Note: If the first line is commented out and the version information is written in the second or later line,
+	 * the appropriate version information will be added to the first line and the user-defined version information
+	 * in the second or later line will be removed.
+	 */
 	private static __convertOrInsertVersionGLSLES3(splittedShaderCode: string[]) {
 		const inReg = /^(?![\/])[\t ]*#[\t ]*version[\t ]+.*/;
 		this.__removeFirstMatchingLine(splittedShaderCode, inReg);

--- a/src/main/ShaderTransformer.ts
+++ b/src/main/ShaderTransformer.ts
@@ -4,6 +4,7 @@ export default class ShaderTransformer {
 	 * Translate a GLSL ES3 shader code to a GLSL ES1 shader code
 	 */
 	static _transformToGLSLES1(splittedShaderCode: string[], isFragmentShader: boolean) {
+		this.__convertOrInsertVersionGLSLES1(splittedShaderCode);
 		this.__convertIn(splittedShaderCode, isFragmentShader);
 		this.__convertOut(splittedShaderCode);
 		this.__removeLayout(splittedShaderCode);
@@ -18,6 +19,7 @@ export default class ShaderTransformer {
 	 * Translate a GLSL ES1 shader code to a GLSL ES3 shader code
 	 */
 	static _transformToGLSLES3(splittedShaderCode: string[], isFragmentShader: boolean) {
+		this.__convertOrInsertVersionGLSLES3(splittedShaderCode);
 		this.__convertAttribute(splittedShaderCode, isFragmentShader);
 		this.__convertVarying(splittedShaderCode, isFragmentShader);
 		this.__convertTextureCube(splittedShaderCode);
@@ -43,6 +45,21 @@ export default class ShaderTransformer {
 			console.error('Invalid Version')
 			return splittedShaderCode;
 		}
+	}
+
+	private static __convertOrInsertVersionGLSLES1(splittedShaderCode: string[]) {
+		const inReg = /^(?![\/])[\t ]*#[\t ]*version[\t ]+.*/;
+		this.__removeFirstMatchingLine(splittedShaderCode, inReg);
+
+		splittedShaderCode.unshift('#version 100');
+	}
+
+	private static __convertOrInsertVersionGLSLES3(splittedShaderCode: string[]) {
+		const inReg = /^(?![\/])[\t ]*#[\t ]*version[\t ]+.*/;
+		this.__removeFirstMatchingLine(splittedShaderCode, inReg);
+
+		splittedShaderCode.unshift('#define GLSL_ES3');
+		splittedShaderCode.unshift('#version 300 es');
 	}
 
 	/**
@@ -273,6 +290,15 @@ export default class ShaderTransformer {
 	private static __replaceRow(splittedShaderCode: string[], inReg: RegExp, inAsES1: any) {
 		for (let i = 0; i < splittedShaderCode.length; i++) {
 			splittedShaderCode[i] = splittedShaderCode[i].replace(inReg, inAsES1);
+		}
+	}
+
+	private static __removeFirstMatchingLine(splittedShaderCode: string[], inReg: RegExp) {
+		for (let i = 0; i < splittedShaderCode.length; i++) {
+			if (splittedShaderCode[i].match(inReg)) {
+				splittedShaderCode.splice(i, 1);
+				break;
+			}
 		}
 	}
 }

--- a/src/main/ShaderTransformer.ts
+++ b/src/main/ShaderTransformer.ts
@@ -82,7 +82,7 @@ export default class ShaderTransformer {
 			}
 		}
 
-		this.__replaceRow(splittedShaderCode, inReg, inAsES1);
+		this.__replaceLine(splittedShaderCode, inReg, inAsES1);
 	}
 
 	/**
@@ -96,7 +96,7 @@ export default class ShaderTransformer {
 			return 'varying ' + p1;
 		}
 
-		this.__replaceRow(splittedShaderCode, inReg, inAsES1);
+		this.__replaceLine(splittedShaderCode, inReg, inAsES1);
 	}
 
 	/**
@@ -106,7 +106,7 @@ export default class ShaderTransformer {
 	 */
 	private static __removeLayout(splittedShaderCode: string[]) {
 		const inReg = /^(?![\/])[\t ]*layout[\t ]*\([\t ]*location[\t ]*\=[\t ]*\d[\t ]*\)[\t ]+/g;
-		this.__replaceRow(splittedShaderCode, inReg, '');
+		this.__replaceLine(splittedShaderCode, inReg, '');
 	}
 
 	/**
@@ -121,10 +121,10 @@ export default class ShaderTransformer {
 		const sbl = this.__regSymbols();
 
 		for (let i = 0; i < splittedShaderCode.length; i++) {
-			const row = splittedShaderCode[i];
+			const line = splittedShaderCode[i];
 
 			let reg = new RegExp(`(${sbl}+)(textureProj)(${sbl}+)`, 'g');
-			let match = row.match(/textureProj[\t ]*\([\t ]*(\w+),/);
+			let match = line.match(/textureProj[\t ]*\([\t ]*(\w+),/);
 			if (match) {
 				const name = match[1];
 				const uniformSamplerMap = this.__createUniformSamplerMap(splittedShaderCode, i);
@@ -148,7 +148,7 @@ export default class ShaderTransformer {
 			}
 
 			reg = new RegExp(`(${sbl}+)(texture)(${sbl}+)`, 'g');
-			match = row.match(/texture[\t ]*\([\t ]*(\w+),/);
+			match = line.match(/texture[\t ]*\([\t ]*(\w+),/);
 			if (match) {
 				const name = match[1];
 				const uniformSamplerMap = this.__createUniformSamplerMap(splittedShaderCode, i);
@@ -175,12 +175,12 @@ export default class ShaderTransformer {
 		}
 	}
 
-	private static __createUniformSamplerMap(splittedShaderCode: string[], row_i: number) {
+	private static __createUniformSamplerMap(splittedShaderCode: string[], line_i: number) {
 		const uniformSamplerMap = new Map();
 
-		for (let i = 0; i < row_i; i++) {
-			const row = splittedShaderCode[i];
-			const match = row.match(/^(?![\/])[\t ]*\w*[\t ]*(sampler\w+)[\t ]+(\w+)/);
+		for (let i = 0; i < line_i; i++) {
+			const line = splittedShaderCode[i];
+			const match = line.match(/^(?![\/])[\t ]*\w*[\t ]*(sampler\w+)[\t ]+(\w+)/);
 			if (match) {
 				const samplerType = match[1];
 				const name = match[2];
@@ -203,7 +203,7 @@ export default class ShaderTransformer {
 		const inReg = /^(?![\/])[\t ]*attribute[\t ]+/g;
 		const inAsES3 = 'in ';
 
-		this.__replaceRow(splittedShaderCode, inReg, inAsES3);
+		this.__replaceLine(splittedShaderCode, inReg, inAsES3);
 	}
 
 	/**
@@ -215,7 +215,7 @@ export default class ShaderTransformer {
 		const inReg = /^(?![\/])[\t ]*varying[\t ]+/g;
 		const inAsES3 = isFragmentShader ? 'in ' : 'out ';
 
-		this.__replaceRow(splittedShaderCode, inReg, inAsES3);
+		this.__replaceLine(splittedShaderCode, inReg, inAsES3);
 	}
 
 	/**
@@ -228,7 +228,7 @@ export default class ShaderTransformer {
 		const reg = new RegExp(`(${sbl}+)(textureCube)(${sbl}+)`, 'g');
 		const inAsES3 = 'texture';
 
-		this.__replaceRow(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
+		this.__replaceLine(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
 	}
 
 	/**
@@ -241,7 +241,7 @@ export default class ShaderTransformer {
 		const reg = new RegExp(`(${sbl}+)(texture2D)(${sbl}+)`, 'g');
 		const inAsES3 = 'texture';
 
-		this.__replaceRow(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
+		this.__replaceLine(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
 	}
 
 	/**
@@ -254,7 +254,7 @@ export default class ShaderTransformer {
 		const reg = new RegExp(`(${sbl}+)(texture2DProj)(${sbl}+)`, 'g');
 		const inAsES3 = 'textureProj';
 
-		this.__replaceRow(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
+		this.__replaceLine(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
 	}
 
 	/**
@@ -267,7 +267,7 @@ export default class ShaderTransformer {
 		const reg = new RegExp(`(${sbl}+)(texture3D)(${sbl}+)`, 'g');
 		const inAsES3 = 'texture';
 
-		this.__replaceRow(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
+		this.__replaceLine(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
 	}
 
 	/**
@@ -280,14 +280,14 @@ export default class ShaderTransformer {
 		const reg = new RegExp(`(${sbl}+)(texture3DProj)(${sbl}+)`, 'g');
 		const inAsES3 = 'textureProj';
 
-		this.__replaceRow(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
+		this.__replaceLine(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
 	}
 
 	private static __regSymbols() {
 		return `[!"#$%&'()\*\+\-\.,\/:;<=>?@\[\\\]^` + '`{|}~\t\n ]';
 	}
 
-	private static __replaceRow(splittedShaderCode: string[], inReg: RegExp, inAsES1: any) {
+	private static __replaceLine(splittedShaderCode: string[], inReg: RegExp, inAsES1: any) {
 		for (let i = 0; i < splittedShaderCode.length; i++) {
 			splittedShaderCode[i] = splittedShaderCode[i].replace(inReg, inAsES1);
 		}

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -47,7 +47,7 @@ export default class Shaderity {
 
 		const transformedSplittedShaderCode
 			= ShaderTransformer._transformToGLSLES1(splittedShaderCode, isFragmentShader);
-		const resultCode = this._joinSplittedRow(transformedSplittedShaderCode);
+		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
 			code: resultCode,
@@ -63,7 +63,7 @@ export default class Shaderity {
 		const isFragmentShader = this.isFragmentShader(obj);
 		const transformedSplittedShaderCode
 			= ShaderTransformer._transformToGLSLES3(splittedShaderCode, isFragmentShader);
-		const resultCode = this._joinSplittedRow(transformedSplittedShaderCode);
+		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
 			code: resultCode,
@@ -79,7 +79,7 @@ export default class Shaderity {
 		const isFragmentShader = this.isFragmentShader(obj);
 		const transformedSplittedShaderCode
 			= ShaderTransformer._transformTo(version, splittedShaderCode, isFragmentShader);
-		const resultCode = this._joinSplittedRow(transformedSplittedShaderCode);
+		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
 			code: resultCode,
@@ -93,8 +93,8 @@ export default class Shaderity {
 		return source.split(/\r\n|\n/);
 	}
 
-	private _joinSplittedRow(splittedRow: string[]) {
-		return splittedRow.join('\n');
+	private _joinSplittedLine(splittedLine: string[]) {
+		return splittedLine.join('\n');
 	}
 
 	/**
@@ -125,7 +125,7 @@ export default class Shaderity {
 
 		splittedShaderCode.unshift(`#define ${defStr}`);
 
-		copy.code = this._joinSplittedRow(splittedShaderCode);
+		copy.code = this._joinSplittedLine(splittedShaderCode);
 
 		return copy;
 	}

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -19,7 +19,8 @@ test('detect shader stage correctly', async() => {
 
 test('convert to ES1 correctly (fragment)', async() => {
   const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformToGLSLES1(simpleFragment).code).toBe(`precision mediump float;
+  expect(shaderity.transformToGLSLES1(simpleFragment).code).toBe(`#version 100
+precision mediump float;
 
 varying vec4 vColor;
 varying vec4 vTexcoord;
@@ -32,7 +33,8 @@ void main() {
 
 test('convert to ES1 correctly (vertex)', async() => {
   const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformToGLSLES1(simpleVertex).code).toBe(`attribute vec3 position;
+  expect(shaderity.transformToGLSLES1(simpleVertex).code).toBe(`#version 100
+attribute vec3 position;
 attribute vec4 color;
 uniform mat4 matrix;
 varying vec4 vColor;
@@ -46,7 +48,9 @@ void main (void) {
 
 test('convert to ES3 correctly (texture)', async() => {
   const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformToGLSLES3(textureFragmentES1).code).toBe(`in vec2 v_texcoord;
+  expect(shaderity.transformToGLSLES3(textureFragmentES1).code).toBe(`#version 300 es
+#define GLSL_ES3
+in vec2 v_texcoord;
 in vec3 v_texcoord3;
 uniform sampler2D u_texture;
 uniform sampler3D u_texture_3D;
@@ -64,7 +68,8 @@ void main (void) {
 
 test('convert to ES1 correctly (texture)', async() => {
   const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformTo('WebGL1', textureFragmentES3).code).toBe(`varying vec2 v_texcoord;
+  expect(shaderity.transformTo('WebGL1', textureFragmentES3).code).toBe(`#version 100
+varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D u_texture;
 uniform sampler3D u_texture_3D;
@@ -82,7 +87,8 @@ void main (void) {
 
 test('convert to ES1 correctly (texture 2)', async() => {
   const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformTo('WebGL1', textureFuncFragmentES3).code).toBe(`varying vec2 v_texcoord;
+  expect(shaderity.transformTo('WebGL1', textureFuncFragmentES3).code).toBe(`#version 100
+varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D texture1;
 uniform samplerCube texture2;
@@ -204,7 +210,8 @@ test('test removing `layout(location = x)` from ES3 shader to ES1 shader', async
   const shaderity = Shaderity.getInstance();
   const shaderityObject = shaderity.transformToGLSLES1(layoutUniformFragmentES3);
   expect(shaderityObject.code).toBe(
-    `varying vec2 v_texcoord;
+    `#version 100
+varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D u_texture;
 uniform samplerCube u_textureCube;

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -50,6 +50,8 @@ test('convert to ES3 correctly (texture)', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.transformToGLSLES3(textureFragmentES1).code).toBe(`#version 300 es
 #define GLSL_ES3
+// texture_es1.frag
+
 in vec2 v_texcoord;
 in vec3 v_texcoord3;
 uniform sampler2D u_texture;
@@ -69,6 +71,7 @@ void main (void) {
 test('convert to ES1 correctly (texture)', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.transformTo('WebGL1', textureFragmentES3).code).toBe(`#version 100
+
 varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D u_texture;


### PR DESCRIPTION
The version information will be embedded (or transformed) in the first line of the shader when the shader is transformed using the ShaderTransformer method. In glsl es3 mode, the '#define GLSL_ES3' directive is added to the second line. The user can perform different operations in glsl es1 and 3 using this directive.