### PR TITLE
feat: support 3d texture from glsl es1

### DIFF
--- a/assets/texture_es1.frag
+++ b/assets/texture_es1.frag
@@ -1,10 +1,13 @@
 varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D u_texture;
+uniform sampler3D u_texture_3D;
 uniform samplerCube u_textureCube;
 
 void main (void) {
   gl_FragColor = texture2D(u_texture, v_texcoord);
   gl_FragColor = textureCube(u_textureCube, v_texcoord3);
   gl_FragColor = texture2DProj(u_texture, v_texcoord);
+  gl_FragColor = texture3D(u_texture_3D, v_texcoord);
+  gl_FragColor = texture3DProj(u_texture_3D, v_texcoord);
 }

--- a/assets/texture_es3.frag
+++ b/assets/texture_es3.frag
@@ -1,10 +1,13 @@
 in vec2 v_texcoord;
 in vec3 v_texcoord3;
 uniform sampler2D u_texture;
+uniform sampler3D u_texture_3D;
 uniform samplerCube u_textureCube;
 
 void main (void) {
   gl_FragColor = texture(u_texture, v_texcoord);
   gl_FragColor = texture(u_textureCube, v_texcoord3);
   gl_FragColor = textureProj(u_texture, v_texcoord);
+  gl_FragColor = texture(u_texture_3D, v_texcoord);
+  gl_FragColor = textureProj(u_texture_3D, v_texcoord);
 }

--- a/src/main/ShaderTransformer.ts
+++ b/src/main/ShaderTransformer.ts
@@ -12,9 +12,11 @@ export default class ShaderTransformer {
 	static _transformToGLSLES3(splittedShaderCode: string[], isFragmentShader: boolean) {
 		this.__convertAttribute(splittedShaderCode, isFragmentShader);
 		this.__convertVarying(splittedShaderCode, isFragmentShader);
-		this.__convertTexture2D(splittedShaderCode);
 		this.__convertTextureCube(splittedShaderCode);
+		this.__convertTexture2D(splittedShaderCode);
 		this.__convertTexture2DProd(splittedShaderCode);
+		this.__convertTexture3D(splittedShaderCode);
+		this.__convertTexture3DProd(splittedShaderCode);
 		const transformedSplittedShaderCode = splittedShaderCode;
 
 		return transformedSplittedShaderCode;
@@ -174,6 +176,22 @@ export default class ShaderTransformer {
 	private static __convertTexture2DProd(splittedShaderCode: string[]) {
 		const sbl = this.__regSymbols();
 		const reg = new RegExp(`(${sbl}+)(texture2DProj)(${sbl}+)`, 'g');
+		const inAsES3 = 'textureProj';
+
+		this.__replaceRow(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
+	}
+
+	private static __convertTexture3D(splittedShaderCode: string[]) {
+		const sbl = this.__regSymbols();
+		const reg = new RegExp(`(${sbl}+)(texture3D)(${sbl}+)`, 'g');
+		const inAsES3 = 'texture';
+
+		this.__replaceRow(splittedShaderCode, reg, '$1' + inAsES3 + '$3');
+	}
+
+	private static __convertTexture3DProd(splittedShaderCode: string[]) {
+		const sbl = this.__regSymbols();
+		const reg = new RegExp(`(${sbl}+)(texture3DProj)(${sbl}+)`, 'g');
 		const inAsES3 = 'textureProj';
 
 		this.__replaceRow(splittedShaderCode, reg, '$1' + inAsES3 + '$3');

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -67,12 +67,15 @@ test('convert to ES1 correctly (texture)', async() => {
   expect(shaderity.transformTo('WebGL1', textureFragmentES3).code).toBe(`varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D u_texture;
+uniform sampler3D u_texture_3D;
 uniform samplerCube u_textureCube;
 
 void main (void) {
   gl_FragColor = texture2D(u_texture, v_texcoord);
   gl_FragColor = textureCube(u_textureCube, v_texcoord3);
   gl_FragColor = texture2DProj(u_texture, v_texcoord);
+  gl_FragColor = texture3D(u_texture_3D, v_texcoord);
+  gl_FragColor = texture3DProj(u_texture_3D, v_texcoord);
 }
 `);
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -49,12 +49,15 @@ test('convert to ES3 correctly (texture)', async() => {
   expect(shaderity.transformToGLSLES3(textureFragmentES1).code).toBe(`in vec2 v_texcoord;
 in vec3 v_texcoord3;
 uniform sampler2D u_texture;
+uniform sampler3D u_texture_3D;
 uniform samplerCube u_textureCube;
 
 void main (void) {
   gl_FragColor = texture(u_texture, v_texcoord);
   gl_FragColor = texture(u_textureCube, v_texcoord3);
   gl_FragColor = textureProj(u_texture, v_texcoord);
+  gl_FragColor = texture(u_texture_3D, v_texcoord);
+  gl_FragColor = textureProj(u_texture_3D, v_texcoord);
 }
 `);
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -11,13 +11,13 @@ const reflectionVertexES3 = require('../dist/index_test').reflectionVertexES3;
 const layoutUniformFragmentES3 = require('../dist/index_test').layoutUniformFragmentES3;
 
 
-test('detect shader stage correctly', async () => {
+test('detect shader stage correctly', async() => {
   const shaderity = Shaderity.getInstance();
   expect(simpleFragment.shaderStage).toBe('fragment');
   expect(shaderity.isFragmentShader(simpleFragment)).toBe(true);
 });
 
-test('convert to ES1 correctly (fragment)', async () => {
+test('convert to ES1 correctly (fragment)', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.transformToGLSLES1(simpleFragment).code).toBe(`precision mediump float;
 
@@ -30,7 +30,7 @@ void main() {
 `);
 });
 
-test('convert to ES1 correctly (vertex)', async () => {
+test('convert to ES1 correctly (vertex)', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.transformToGLSLES1(simpleVertex).code).toBe(`attribute vec3 position;
 attribute vec4 color;
@@ -44,7 +44,7 @@ void main (void) {
 `);
 });
 
-test('convert to ES3 correctly (texture)', async () => {
+test('convert to ES3 correctly (texture)', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.transformToGLSLES3(textureFragmentES1).code).toBe(`in vec2 v_texcoord;
 in vec3 v_texcoord3;
@@ -59,7 +59,7 @@ void main (void) {
 `);
 });
 
-test('convert to ES1 correctly (texture)', async () => {
+test('convert to ES1 correctly (texture)', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.transformTo('WebGL1', textureFragmentES3).code).toBe(`varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
@@ -74,7 +74,7 @@ void main (void) {
 `);
 });
 
-test('convert to ES1 correctly (texture 2)', async () => {
+test('convert to ES1 correctly (texture 2)', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.transformTo('WebGL1', textureFuncFragmentES3).code).toBe(`varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
@@ -106,7 +106,7 @@ void main (void) {
 `);
 });
 
-test('test dynamic template', async () => {
+test('test dynamic template', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.fillTemplate(dynamicTemplateFragment, {
     var_a: `Line1
@@ -128,7 +128,7 @@ void main() {
 `);
 });
 
-test('test insert definition', async () => {
+test('test insert definition', async() => {
   const shaderity = Shaderity.getInstance();
   expect(shaderity.insertDefinition(insertDefinitionVertex, 'GLSL_ES3').code).toBe(`#define GLSL_ES3
 in vec3 position;
@@ -139,80 +139,66 @@ void main (void) {
 `);
 });
 
-test('test attribute variable reflection (ES1)', async () => {
+test('test attribute variable reflection (ES1)', async() => {
   const shaderity = Shaderity.getInstance();
   const reflection = shaderity.reflect(reflectionVertexES1);
-  expect(reflection.attributes[0]).toStrictEqual(
-    {
-      name: 'a_position',
-      type: 'vec3',
-      semantic: 'POSITION'
-    }
-    );
-  expect(reflection.attributes[1]).toStrictEqual(
-    {
-      name: 'a_uv',
-      type: 'vec2',
-      semantic: 'TEXCOORD_0'
-    }
-    );
+  expect(reflection.attributes[0]).toStrictEqual({
+    name: 'a_position',
+    type: 'vec3',
+    semantic: 'POSITION'
+  });
+  expect(reflection.attributes[1]).toStrictEqual({
+    name: 'a_uv',
+    type: 'vec2',
+    semantic: 'TEXCOORD_0'
+  });
 });
 
-test('test varying variable reflection (ES1)', async () => {
+test('test varying variable reflection (ES1)', async() => {
   const shaderity = Shaderity.getInstance();
   const reflection = shaderity.reflect(reflectionVertexES1);
-  expect(reflection.varyings[0]).toStrictEqual(
-    {
-      name: 'v_position',
-      type: 'vec3',
-      inout: 'out'
-    }
-    );
+  expect(reflection.varyings[0]).toStrictEqual({
+    name: 'v_position',
+    type: 'vec3',
+    inout: 'out'
+  });
 });
 
-test('test uniform variable reflection (ES1)', async () => {
+test('test uniform variable reflection (ES1)', async() => {
   const shaderity = Shaderity.getInstance();
   const reflection = shaderity.reflect(reflectionVertexES1);
-  expect(reflection.uniforms[0]).toStrictEqual(
-    {
-      name: 'u_worldMatrix',
-      type: 'vec4',
-      semantic: 'WorldMatrix'
-    }
-    );
-  expect(reflection.uniforms[1]).toStrictEqual(
-    {
-      name: 'u_texture',
-      type: 'sampler2D',
-      semantic: 'DataTexture'
-    }
-    );
+  expect(reflection.uniforms[0]).toStrictEqual({
+    name: 'u_worldMatrix',
+    type: 'vec4',
+    semantic: 'WorldMatrix'
+  });
+  expect(reflection.uniforms[1]).toStrictEqual({
+    name: 'u_texture',
+    type: 'sampler2D',
+    semantic: 'DataTexture'
+  });
 });
 
-test('test attribute variable reflection (ES3)', async () => {
+test('test attribute variable reflection (ES3)', async() => {
   const shaderity = Shaderity.getInstance();
   const reflection = shaderity.reflect(reflectionVertexES3);
-  expect(reflection.attributes[0]).toStrictEqual(
-    {
-      name: 'a_position',
-      type: 'vec3',
-      semantic: 'POSITION'
-    }
-    );
-  expect(reflection.attributes[1]).toStrictEqual(
-    {
-      name: 'a_uv',
-      type: 'vec2',
-      semantic: 'TEXCOORD_0'
-    }
-    );
+  expect(reflection.attributes[0]).toStrictEqual({
+    name: 'a_position',
+    type: 'vec3',
+    semantic: 'POSITION'
+  });
+  expect(reflection.attributes[1]).toStrictEqual({
+    name: 'a_uv',
+    type: 'vec2',
+    semantic: 'TEXCOORD_0'
+  });
 });
 
-test('test removing `layout(location = x)` from ES3 shader to ES1 shader', async () => {
+test('test removing `layout(location = x)` from ES3 shader to ES1 shader', async() => {
   const shaderity = Shaderity.getInstance();
   const shaderityObject = shaderity.transformToGLSLES1(layoutUniformFragmentES3);
   expect(shaderityObject.code).toBe(
-`varying vec2 v_texcoord;
+    `varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D u_texture;
 uniform samplerCube u_textureCube;
@@ -224,13 +210,11 @@ void main (void) {
   gl_FragColor = texture2DProj(u_texture, v_texcoord);
 }
 `
-    );
-      const layoutUniform = shaderity.reflect(shaderityObject);
-  expect(layoutUniform.uniforms[1]).toStrictEqual(
-    {
-      name: 'u_textureCube',
-      type: 'samplerCube',
-      semantic: 'UNKNOWN'
-    }
-    );
+  );
+  const layoutUniform = shaderity.reflect(shaderityObject);
+  expect(layoutUniform.uniforms[1]).toStrictEqual({
+    name: 'u_textureCube',
+    type: 'samplerCube',
+    semantic: 'UNKNOWN'
+  });
 });


### PR DESCRIPTION
This PR allows us to convert 'texture3D' to 'texture' and 'texture3DProj' to 'textureProj' when converting glsl es3 to glsl es1.