### PR TITLE
refactor: move shader edit feature from Shaderity.ts to ShaderEditor.ts

### DIFF
--- a/src/main/ShaderEditor.ts
+++ b/src/main/ShaderEditor.ts
@@ -1,0 +1,14 @@
+export default class ShaderEditor {
+	static _insertDefinition(splittedShaderCode: string[], definition: string) {
+		const defStr = definition.replace(/#define[\t ]+/, '');
+
+		splittedShaderCode.unshift(`#define ${defStr}`);
+	}
+
+	static _fillTemplate(shaderCode: string, arg: {[s: string]: any}) {
+		const templateString = shaderCode.replace(/\/\*[\t ]*shaderity:[\t ]*(@{[\t ]*)(\S+)([\t ]*})[\t ]*\*\//g, '${this.$2}');
+
+		const resultCode = new Function("return `" + templateString + "`;").call(arg);
+		return resultCode;
+	}
+}

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -1,6 +1,7 @@
 import Reflection from './Reflection';
 import {ShaderityObject} from '../types/type';
 import ShaderTransformer from './ShaderTransformer';
+import ShaderEditor from './ShaderEditor';
 
 export default class Shaderity {
 	private static __instance: Shaderity;
@@ -105,14 +106,7 @@ export default class Shaderity {
 	fillTemplate(obj: ShaderityObject, arg: {[s: string]: any}) {
 		const copy = this.copyShaderityObject(obj);
 
-
-		const templateString = obj.code.replace(/\/\*[\t ]*shaderity:[\t ]*(@{[\t ]*)(\S+)([\t ]*})[\t ]*\*\//g, '${this.$2}');
-
-
-		const fillTemplate = function (templateString: string, arg: {[s: string]: any}) {
-			return new Function("return `" + templateString + "`;").call(arg);
-		}
-		copy.code = fillTemplate(templateString, arg);
+		copy.code = ShaderEditor._fillTemplate(copy.code, arg);
 
 		return copy;
 	}
@@ -121,10 +115,7 @@ export default class Shaderity {
 		const copy = this.copyShaderityObject(obj);
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
-		const defStr = definition.replace(/#define[\t ]+/, '');
-
-		splittedShaderCode.unshift(`#define ${defStr}`);
-
+		ShaderEditor._insertDefinition(splittedShaderCode, definition);
 		copy.code = this._joinSplittedLine(splittedShaderCode);
 
 		return copy;


### PR DESCRIPTION
In this PR, all the codes related to the shader edit has been moved to the ShaderEditor class.