### PR TITLE
build: support shaderity loader v0.0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "raw-loader": "^3.0.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^2.6.3",
-    "shaderity-loader": "0.0.15",
+    "shaderity-loader": "0.0.16",
     "ts-jest": "^24.0.2",
     "ts-loader": "^6.0.2",
     "typedoc": "^0.14.2",

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -36,7 +36,8 @@ export default class Shaderity {
 	copyShaderityObject(obj: ShaderityObject) {
 		const copiedObj: ShaderityObject = {
 			code: obj.code,
-			shaderStage: obj.shaderStage
+			shaderStage: obj.shaderStage,
+			isFragmentShader: obj.isFragmentShader,
 		}
 
 		return copiedObj;
@@ -53,6 +54,7 @@ export default class Shaderity {
 		const resultObj: ShaderityObject = {
 			code: resultCode,
 			shaderStage: obj.shaderStage,
+			isFragmentShader: obj.isFragmentShader,
 		};
 
 		return resultObj;
@@ -69,6 +71,7 @@ export default class Shaderity {
 		const resultObj: ShaderityObject = {
 			code: resultCode,
 			shaderStage: obj.shaderStage,
+			isFragmentShader: obj.isFragmentShader,
 		};
 
 		return resultObj;
@@ -85,6 +88,7 @@ export default class Shaderity {
 		const resultObj: ShaderityObject = {
 			code: resultCode,
 			shaderStage: obj.shaderStage,
+			isFragmentShader: obj.isFragmentShader,
 		};
 
 		return resultObj;

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -22,7 +22,7 @@ export default class Shaderity {
 	}
 
 	isFragmentShader(obj: ShaderityObject) {
-		if (obj.shaderStage === 'fragment' || obj.shaderStage === 'pixel') {
+		if (obj.shaderStage === 'fragment') {
 			return true;
 		} else {
 			return false;

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -13,26 +13,6 @@ export default class Shaderity {
 		return this.__instance;
 	}
 
-	isVertexShader(obj: ShaderityObject) {
-		if (obj.shaderStage === 'vertex') {
-			return true;
-		} else {
-			return false;
-		}
-	}
-
-	isFragmentShader(obj: ShaderityObject) {
-		if (obj.shaderStage === 'fragment') {
-			return true;
-		} else {
-			return false;
-		}
-	}
-
-	isPixelShader(obj: ShaderityObject) {
-		return this.isFragmentShader(obj);
-	}
-
 	copyShaderityObject(obj: ShaderityObject) {
 		const copiedObj: ShaderityObject = {
 			code: obj.code,
@@ -45,10 +25,9 @@ export default class Shaderity {
 
 	transformToGLSLES1(obj: ShaderityObject) {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
-		const isFragmentShader = this.isFragmentShader(obj);
 
 		const transformedSplittedShaderCode
-			= ShaderTransformer._transformToGLSLES1(splittedShaderCode, isFragmentShader);
+			= ShaderTransformer._transformToGLSLES1(splittedShaderCode, obj.isFragmentShader);
 		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
@@ -63,9 +42,8 @@ export default class Shaderity {
 	transformToGLSLES3(obj: ShaderityObject) {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
-		const isFragmentShader = this.isFragmentShader(obj);
 		const transformedSplittedShaderCode
-			= ShaderTransformer._transformToGLSLES3(splittedShaderCode, isFragmentShader);
+			= ShaderTransformer._transformToGLSLES3(splittedShaderCode, obj.isFragmentShader);
 		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
@@ -80,9 +58,8 @@ export default class Shaderity {
 	transformTo(version: string, obj: ShaderityObject) {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
-		const isFragmentShader = this.isFragmentShader(obj);
 		const transformedSplittedShaderCode
-			= ShaderTransformer._transformTo(version, splittedShaderCode, isFragmentShader);
+			= ShaderTransformer._transformTo(version, splittedShaderCode, obj.isFragmentShader);
 		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -2,7 +2,8 @@ export type ShaderStageStr = 'vertex' | 'fragment';
 
 export type ShaderityObject = {
 	code: string,
-	shaderStage: ShaderStageStr
+	shaderStage: ShaderStageStr,
+	isFragmentShader: boolean
 };
 
 export type VarType = 'unknown' | 'float' | 'int' |

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,4 +1,4 @@
-export type ShaderStageStr = 'vertex' | 'fragment' | 'pixel'
+export type ShaderStageStr = 'vertex' | 'fragment';
 
 export type ShaderityObject = {
 	code: string,

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -12,9 +12,8 @@ const layoutUniformFragmentES3 = require('../dist/index_test').layoutUniformFrag
 
 
 test('detect shader stage correctly', async() => {
-  const shaderity = Shaderity.getInstance();
   expect(simpleFragment.shaderStage).toBe('fragment');
-  expect(shaderity.isFragmentShader(simpleFragment)).toBe(true);
+  expect(simpleFragment.isFragmentShader).toBe(true);
 });
 
 test('convert to ES1 correctly (fragment)', async() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5499,17 +5499,17 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaderity-loader@0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/shaderity-loader/-/shaderity-loader-0.0.15.tgz#668f74db97cd7f102d1497ed2ac57933fbbc3a1d"
-  integrity sha512-wGXFTEdBa4RiB1pxbvRHBRAsKAPUGACregbHP7XnnWDzP8eJ8jVgOAXwLtvR5ZBCUhL/O6b1hcMk38YznfgkGw==
+shaderity-loader@0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/shaderity-loader/-/shaderity-loader-0.0.16.tgz#96fabf850164c8d1ae49870a6498694fe36a03fa"
+  integrity sha512-rYZColjslGVYkQFPhs0YUPKCSaDZBIOBSfkYe9aW8ZxHGfMmZbIl5yQ/FlRdQ+30XziXIPA/gAKvMxsBPushNA==
   dependencies:
-    shaderity-node "0.0.5"
+    shaderity-node "0.0.6"
 
-shaderity-node@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/shaderity-node/-/shaderity-node-0.0.5.tgz#5ce9e1adb3d1357a67ae63c7494659351ee367dd"
-  integrity sha512-xAu9TxoprgfikPm5HKpsaG5M/EP0xeHWUOepOaIbDxwRyBhnDRj6VdlLH8bYVOOWh9CbsXz37aKgteCw+h2H4A==
+shaderity-node@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/shaderity-node/-/shaderity-node-0.0.6.tgz#4da236be537978442c77898116c2a06c5ffc1dda"
+  integrity sha512-SBN7sLsDPzq/IGna/d8PFuOU8PxfSIgmue9q6B5OxZUQCmOKkEFReMFadD7QtCWaaoizLGlsFeoVIHWvtOm6kw==
 
 shallow-clone@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
This PR supports the shaderity loader v0.0.16.

**Breaking Change**
Shaderity.isVertexShader, Shaderity.isFragmentShader and Shaderity.isPixelShader have been removed. Use ShaderityObject.isFragmentShader property instead. 


Shaderity is responsible only for the internal data of the file.　Information not related to the internal data of the file, such as the file extension, is handled by the other shaderity series.