### PR TITLE
refactor: organize shaderity class

### DIFF
--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -5,11 +5,11 @@ import ShaderEditor from './ShaderEditor';
 
 export default class Shaderity {
 	static transformToGLSLES1(obj: ShaderityObject) {
-		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
 			= ShaderTransformer._transformToGLSLES1(splittedShaderCode, obj.isFragmentShader);
-		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
+		const resultCode = this.__joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
 			code: resultCode,
@@ -21,11 +21,11 @@ export default class Shaderity {
 	}
 
 	static transformToGLSLES3(obj: ShaderityObject) {
-		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
 			= ShaderTransformer._transformToGLSLES3(splittedShaderCode, obj.isFragmentShader);
-		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
+		const resultCode = this.__joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
 			code: resultCode,
@@ -37,11 +37,11 @@ export default class Shaderity {
 	}
 
 	static transformTo(version: string, obj: ShaderityObject) {
-		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
 			= ShaderTransformer._transformTo(version, splittedShaderCode, obj.isFragmentShader);
-		const resultCode = this._joinSplittedLine(transformedSplittedShaderCode);
+		const resultCode = this.__joinSplittedLine(transformedSplittedShaderCode);
 
 		const resultObj: ShaderityObject = {
 			code: resultCode,
@@ -67,7 +67,7 @@ export default class Shaderity {
 	 */
 	// The template pattern is	/* shaderity: @{key} */
 	static fillTemplate(obj: ShaderityObject, arg: TemplateObject) {
-		const copy = this.copyShaderityObject(obj);
+		const copy = this.__copyShaderityObject(obj);
 
 		copy.code = ShaderEditor._fillTemplate(copy.code, arg);
 
@@ -75,17 +75,17 @@ export default class Shaderity {
 	}
 
 	static insertDefinition(obj: ShaderityObject, definition: string) {
-		const copy = this.copyShaderityObject(obj);
-		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
+		const copy = this.__copyShaderityObject(obj);
+		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
 		ShaderEditor._insertDefinition(splittedShaderCode, definition);
-		copy.code = this._joinSplittedLine(splittedShaderCode);
+		copy.code = this.__joinSplittedLine(splittedShaderCode);
 
 		return copy;
 	}
 
 	static reflect(obj: ShaderityObject): Reflection {
-		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 		const shaderStage = obj.shaderStage;
 
 		const reflection = new Reflection(splittedShaderCode, shaderStage);
@@ -94,14 +94,14 @@ export default class Shaderity {
 	}
 
 	static createReflectionObject(obj: ShaderityObject): Reflection {
-		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
+		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 		const shaderStage = obj.shaderStage;
 
 		const reflection = new Reflection(splittedShaderCode, shaderStage);
 		return reflection;
 	}
 
-	private static copyShaderityObject(obj: ShaderityObject) {
+	private static __copyShaderityObject(obj: ShaderityObject) {
 		const copiedObj: ShaderityObject = {
 			code: obj.code,
 			shaderStage: obj.shaderStage,
@@ -111,11 +111,11 @@ export default class Shaderity {
 		return copiedObj;
 	}
 
-	private static _splitByLineFeedCode(source: string) {
+	private static __splitByLineFeedCode(source: string) {
 		return source.split(/\r\n|\n/);
 	}
 
-	private static _joinSplittedLine(splittedLine: string[]) {
+	private static __joinSplittedLine(splittedLine: string[]) {
 		return splittedLine.join('\n');
 	}
 }

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -4,16 +4,7 @@ import ShaderTransformer from './ShaderTransformer';
 import ShaderEditor from './ShaderEditor';
 
 export default class Shaderity {
-	private static __instance: Shaderity;
-
-	static getInstance(): Shaderity {
-		if (!this.__instance) {
-			this.__instance = new Shaderity();
-		}
-		return this.__instance;
-	}
-
-	copyShaderityObject(obj: ShaderityObject) {
+	static copyShaderityObject(obj: ShaderityObject) {
 		const copiedObj: ShaderityObject = {
 			code: obj.code,
 			shaderStage: obj.shaderStage,
@@ -23,7 +14,7 @@ export default class Shaderity {
 		return copiedObj;
 	}
 
-	transformToGLSLES1(obj: ShaderityObject) {
+	static transformToGLSLES1(obj: ShaderityObject) {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
@@ -39,7 +30,7 @@ export default class Shaderity {
 		return resultObj;
 	}
 
-	transformToGLSLES3(obj: ShaderityObject) {
+	static transformToGLSLES3(obj: ShaderityObject) {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
@@ -55,7 +46,7 @@ export default class Shaderity {
 		return resultObj;
 	}
 
-	transformTo(version: string, obj: ShaderityObject) {
+	static transformTo(version: string, obj: ShaderityObject) {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
@@ -71,11 +62,11 @@ export default class Shaderity {
 		return resultObj;
 	}
 
-	private _splitByLineFeedCode(source: string) {
+	private static _splitByLineFeedCode(source: string) {
 		return source.split(/\r\n|\n/);
 	}
 
-	private _joinSplittedLine(splittedLine: string[]) {
+	private static _joinSplittedLine(splittedLine: string[]) {
 		return splittedLine.join('\n');
 	}
 
@@ -93,7 +84,7 @@ export default class Shaderity {
 	 * then the key in a shader code is sample.sampleA.
 	 */
 	// The template pattern is	/* shaderity: @{key} */
-	fillTemplate(obj: ShaderityObject, arg: TemplateObject) {
+	static fillTemplate(obj: ShaderityObject, arg: TemplateObject) {
 		const copy = this.copyShaderityObject(obj);
 
 		copy.code = ShaderEditor._fillTemplate(copy.code, arg);
@@ -101,7 +92,7 @@ export default class Shaderity {
 		return copy;
 	}
 
-	insertDefinition(obj: ShaderityObject, definition: string) {
+	static insertDefinition(obj: ShaderityObject, definition: string) {
 		const copy = this.copyShaderityObject(obj);
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
@@ -111,7 +102,7 @@ export default class Shaderity {
 		return copy;
 	}
 
-	reflect(obj: ShaderityObject): Reflection {
+	static reflect(obj: ShaderityObject): Reflection {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 		const shaderStage = obj.shaderStage;
 
@@ -120,7 +111,7 @@ export default class Shaderity {
 		return reflection;
 	}
 
-	createReflectionObject(obj: ShaderityObject): Reflection {
+	static createReflectionObject(obj: ShaderityObject): Reflection {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 		const shaderStage = obj.shaderStage;
 

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -7,7 +7,7 @@ export default class Shaderity {
 	// =========================================================================================================
 	// shader transformation functions
 	// =========================================================================================================
-	static transformToGLSLES1(obj: ShaderityObject) {
+	public static transformToGLSLES1(obj: ShaderityObject) {
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
@@ -23,7 +23,7 @@ export default class Shaderity {
 		return resultObj;
 	}
 
-	static transformToGLSLES3(obj: ShaderityObject) {
+	public static transformToGLSLES3(obj: ShaderityObject) {
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
@@ -39,7 +39,7 @@ export default class Shaderity {
 		return resultObj;
 	}
 
-	static transformTo(version: string, obj: ShaderityObject) {
+	public static transformTo(version: string, obj: ShaderityObject) {
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
 		const transformedSplittedShaderCode
@@ -72,7 +72,7 @@ export default class Shaderity {
 	 * then the key in a shader code is sample.sampleA.
 	 */
 	// The template pattern is	/* shaderity: @{key} */
-	static fillTemplate(obj: ShaderityObject, arg: TemplateObject) {
+	public static fillTemplate(obj: ShaderityObject, arg: TemplateObject) {
 		const copy = this.__copyShaderityObject(obj);
 
 		copy.code = ShaderEditor._fillTemplate(copy.code, arg);
@@ -80,7 +80,7 @@ export default class Shaderity {
 		return copy;
 	}
 
-	static insertDefinition(obj: ShaderityObject, definition: string) {
+	public static insertDefinition(obj: ShaderityObject, definition: string) {
 		const copy = this.__copyShaderityObject(obj);
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
@@ -94,7 +94,7 @@ export default class Shaderity {
 	// reflection functions
 	// =========================================================================================================
 
-	static createReflectionObject(obj: ShaderityObject): Reflection {
+	public static createReflectionObject(obj: ShaderityObject): Reflection {
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
 		const reflection = new Reflection(splittedShaderCode, obj.shaderStage);

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -4,6 +4,9 @@ import ShaderTransformer from './ShaderTransformer';
 import ShaderEditor from './ShaderEditor';
 
 export default class Shaderity {
+	// =========================================================================================================
+	// shader transformation functions
+	// =========================================================================================================
 	static transformToGLSLES1(obj: ShaderityObject) {
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 
@@ -52,6 +55,9 @@ export default class Shaderity {
 		return resultObj;
 	}
 
+	// =========================================================================================================
+	// shader edit functions
+	// =========================================================================================================
 	/**
 	 * Find the following template pattern in the shader code and replace key to value
 	 * @param templateObject An object that represents the string before and after the replacement
@@ -84,6 +90,9 @@ export default class Shaderity {
 		return copy;
 	}
 
+	// =========================================================================================================
+	// reflection functions
+	// =========================================================================================================
 	static reflect(obj: ShaderityObject): Reflection {
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
 		const shaderStage = obj.shaderStage;
@@ -101,6 +110,9 @@ export default class Shaderity {
 		return reflection;
 	}
 
+	// =========================================================================================================
+	// private functions
+	// =========================================================================================================
 	private static __copyShaderityObject(obj: ShaderityObject) {
 		const copiedObj: ShaderityObject = {
 			code: obj.code,

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -96,9 +96,8 @@ export default class Shaderity {
 
 	static createReflectionObject(obj: ShaderityObject): Reflection {
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
-		const shaderStage = obj.shaderStage;
 
-		const reflection = new Reflection(splittedShaderCode, shaderStage);
+		const reflection = new Reflection(splittedShaderCode, obj.shaderStage);
 		return reflection;
 	}
 

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -4,16 +4,6 @@ import ShaderTransformer from './ShaderTransformer';
 import ShaderEditor from './ShaderEditor';
 
 export default class Shaderity {
-	static copyShaderityObject(obj: ShaderityObject) {
-		const copiedObj: ShaderityObject = {
-			code: obj.code,
-			shaderStage: obj.shaderStage,
-			isFragmentShader: obj.isFragmentShader,
-		}
-
-		return copiedObj;
-	}
-
 	static transformToGLSLES1(obj: ShaderityObject) {
 		const splittedShaderCode = this._splitByLineFeedCode(obj.code);
 
@@ -60,14 +50,6 @@ export default class Shaderity {
 		};
 
 		return resultObj;
-	}
-
-	private static _splitByLineFeedCode(source: string) {
-		return source.split(/\r\n|\n/);
-	}
-
-	private static _joinSplittedLine(splittedLine: string[]) {
-		return splittedLine.join('\n');
 	}
 
 	/**
@@ -117,5 +99,23 @@ export default class Shaderity {
 
 		const reflection = new Reflection(splittedShaderCode, shaderStage);
 		return reflection;
+	}
+
+	private static copyShaderityObject(obj: ShaderityObject) {
+		const copiedObj: ShaderityObject = {
+			code: obj.code,
+			shaderStage: obj.shaderStage,
+			isFragmentShader: obj.isFragmentShader,
+		}
+
+		return copiedObj;
+	}
+
+	private static _splitByLineFeedCode(source: string) {
+		return source.split(/\r\n|\n/);
+	}
+
+	private static _joinSplittedLine(splittedLine: string[]) {
+		return splittedLine.join('\n');
 	}
 }

--- a/src/main/Shaderity.ts
+++ b/src/main/Shaderity.ts
@@ -93,14 +93,6 @@ export default class Shaderity {
 	// =========================================================================================================
 	// reflection functions
 	// =========================================================================================================
-	static reflect(obj: ShaderityObject): Reflection {
-		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);
-		const shaderStage = obj.shaderStage;
-
-		const reflection = new Reflection(splittedShaderCode, shaderStage);
-		reflection.reflect();
-		return reflection;
-	}
 
 	static createReflectionObject(obj: ShaderityObject): Reflection {
 		const splittedShaderCode = this.__splitByLineFeedCode(obj.code);

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -17,8 +17,7 @@ test('detect shader stage correctly', async() => {
 });
 
 test('convert to ES1 correctly (fragment)', async() => {
-  const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformToGLSLES1(simpleFragment).code).toBe(`#version 100
+  expect(Shaderity.transformToGLSLES1(simpleFragment).code).toBe(`#version 100
 precision mediump float;
 
 varying vec4 vColor;
@@ -31,8 +30,7 @@ void main() {
 });
 
 test('convert to ES1 correctly (vertex)', async() => {
-  const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformToGLSLES1(simpleVertex).code).toBe(`#version 100
+  expect(Shaderity.transformToGLSLES1(simpleVertex).code).toBe(`#version 100
 attribute vec3 position;
 attribute vec4 color;
 uniform mat4 matrix;
@@ -46,8 +44,7 @@ void main (void) {
 });
 
 test('convert to ES3 correctly (texture)', async() => {
-  const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformToGLSLES3(textureFragmentES1).code).toBe(`#version 300 es
+  expect(Shaderity.transformToGLSLES3(textureFragmentES1).code).toBe(`#version 300 es
 #define GLSL_ES3
 // texture_es1.frag
 
@@ -68,8 +65,7 @@ void main (void) {
 });
 
 test('convert to ES1 correctly (texture)', async() => {
-  const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformTo('WebGL1', textureFragmentES3).code).toBe(`#version 100
+  expect(Shaderity.transformTo('WebGL1', textureFragmentES3).code).toBe(`#version 100
 
 varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
@@ -88,8 +84,7 @@ void main (void) {
 });
 
 test('convert to ES1 correctly (texture 2)', async() => {
-  const shaderity = Shaderity.getInstance();
-  expect(shaderity.transformTo('WebGL1', textureFuncFragmentES3).code).toBe(`#version 100
+  expect(Shaderity.transformTo('WebGL1', textureFuncFragmentES3).code).toBe(`#version 100
 varying vec2 v_texcoord;
 varying vec3 v_texcoord3;
 uniform sampler2D texture1;
@@ -121,8 +116,7 @@ void main (void) {
 });
 
 test('test dynamic template', async() => {
-  const shaderity = Shaderity.getInstance();
-  expect(shaderity.fillTemplate(dynamicTemplateFragment, {
+  expect(Shaderity.fillTemplate(dynamicTemplateFragment, {
     var_a: `Line1
 Line2
 Line3`,
@@ -143,8 +137,7 @@ void main() {
 });
 
 test('test insert definition', async() => {
-  const shaderity = Shaderity.getInstance();
-  expect(shaderity.insertDefinition(insertDefinitionVertex, 'GLSL_ES3').code).toBe(`#define GLSL_ES3
+  expect(Shaderity.insertDefinition(insertDefinitionVertex, 'GLSL_ES3').code).toBe(`#define GLSL_ES3
 in vec3 position;
 
 void main (void) {
@@ -154,8 +147,7 @@ void main (void) {
 });
 
 test('test attribute variable reflection (ES1)', async() => {
-  const shaderity = Shaderity.getInstance();
-  const reflection = shaderity.reflect(reflectionVertexES1);
+  const reflection = Shaderity.reflect(reflectionVertexES1);
   expect(reflection.attributes[0]).toStrictEqual({
     name: 'a_position',
     type: 'vec3',
@@ -169,8 +161,7 @@ test('test attribute variable reflection (ES1)', async() => {
 });
 
 test('test varying variable reflection (ES1)', async() => {
-  const shaderity = Shaderity.getInstance();
-  const reflection = shaderity.reflect(reflectionVertexES1);
+  const reflection = Shaderity.reflect(reflectionVertexES1);
   expect(reflection.varyings[0]).toStrictEqual({
     name: 'v_position',
     type: 'vec3',
@@ -179,8 +170,7 @@ test('test varying variable reflection (ES1)', async() => {
 });
 
 test('test uniform variable reflection (ES1)', async() => {
-  const shaderity = Shaderity.getInstance();
-  const reflection = shaderity.reflect(reflectionVertexES1);
+  const reflection = Shaderity.reflect(reflectionVertexES1);
   expect(reflection.uniforms[0]).toStrictEqual({
     name: 'u_worldMatrix',
     type: 'vec4',
@@ -194,8 +184,7 @@ test('test uniform variable reflection (ES1)', async() => {
 });
 
 test('test attribute variable reflection (ES3)', async() => {
-  const shaderity = Shaderity.getInstance();
-  const reflection = shaderity.reflect(reflectionVertexES3);
+  const reflection = Shaderity.reflect(reflectionVertexES3);
   expect(reflection.attributes[0]).toStrictEqual({
     name: 'a_position',
     type: 'vec3',
@@ -209,8 +198,7 @@ test('test attribute variable reflection (ES3)', async() => {
 });
 
 test('test removing `layout(location = x)` from ES3 shader to ES1 shader', async() => {
-  const shaderity = Shaderity.getInstance();
-  const shaderityObject = shaderity.transformToGLSLES1(layoutUniformFragmentES3);
+  const shaderityObject = Shaderity.transformToGLSLES1(layoutUniformFragmentES3);
   expect(shaderityObject.code).toBe(
     `#version 100
 varying vec2 v_texcoord;
@@ -226,7 +214,7 @@ void main (void) {
 }
 `
   );
-  const layoutUniform = shaderity.reflect(shaderityObject);
+  const layoutUniform = Shaderity.reflect(shaderityObject);
   expect(layoutUniform.uniforms[1]).toStrictEqual({
     name: 'u_textureCube',
     type: 'samplerCube',

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -147,7 +147,8 @@ void main (void) {
 });
 
 test('test attribute variable reflection (ES1)', async() => {
-  const reflection = Shaderity.reflect(reflectionVertexES1);
+  const reflection = Shaderity.createReflectionObject(reflectionVertexES1);
+  reflection.reflect();
   expect(reflection.attributes[0]).toStrictEqual({
     name: 'a_position',
     type: 'vec3',
@@ -161,7 +162,8 @@ test('test attribute variable reflection (ES1)', async() => {
 });
 
 test('test varying variable reflection (ES1)', async() => {
-  const reflection = Shaderity.reflect(reflectionVertexES1);
+  const reflection = Shaderity.createReflectionObject(reflectionVertexES1);
+  reflection.reflect();
   expect(reflection.varyings[0]).toStrictEqual({
     name: 'v_position',
     type: 'vec3',
@@ -170,7 +172,8 @@ test('test varying variable reflection (ES1)', async() => {
 });
 
 test('test uniform variable reflection (ES1)', async() => {
-  const reflection = Shaderity.reflect(reflectionVertexES1);
+  const reflection = Shaderity.createReflectionObject(reflectionVertexES1);
+  reflection.reflect();
   expect(reflection.uniforms[0]).toStrictEqual({
     name: 'u_worldMatrix',
     type: 'vec4',
@@ -184,7 +187,8 @@ test('test uniform variable reflection (ES1)', async() => {
 });
 
 test('test attribute variable reflection (ES3)', async() => {
-  const reflection = Shaderity.reflect(reflectionVertexES3);
+  const reflection = Shaderity.createReflectionObject(reflectionVertexES3);
+  reflection.reflect();
   expect(reflection.attributes[0]).toStrictEqual({
     name: 'a_position',
     type: 'vec3',
@@ -214,8 +218,9 @@ void main (void) {
 }
 `
   );
-  const layoutUniform = Shaderity.reflect(shaderityObject);
-  expect(layoutUniform.uniforms[1]).toStrictEqual({
+  const reflection = Shaderity.createReflectionObject(shaderityObject);
+  reflection.reflect();
+  expect(reflection.uniforms[1]).toStrictEqual({
     name: 'u_textureCube',
     type: 'samplerCube',
     semantic: 'UNKNOWN'


### PR DESCRIPTION
This PR organize shaderity class.

**Breaking Change**
1. Shaderity.reflect have been removed. Use Shaderity.createReflectionObject method and reflection.reflect method instead. 
2. Change the methods of the Shaderity class to static methods