### PR TITLE
feat: edit global precision in shader creator

### DIFF
--- a/src/main/ShaderityObjectCreator.ts
+++ b/src/main/ShaderityObjectCreator.ts
@@ -3,6 +3,7 @@ import {
 	ShaderExtensionObject,
 	ShaderityObject,
 	ShaderPrecisionObject,
+	ShaderPrecisionObjectKey,
 	ShaderStageStr
 } from '../types/type';
 import Utility from './Utility';
@@ -115,7 +116,8 @@ export default class ShaderityObjectCreator {
 		// TODO: now implementing
 		const code
 			= this.__createDefineDirectiveShaderCode()
-			+ this.__createExtensionShaderCode();
+			+ this.__createExtensionShaderCode()
+			+ this.__createGlobalPrecisionShaderCode();
 
 		return code;
 	}
@@ -137,4 +139,18 @@ export default class ShaderityObjectCreator {
 
 		return Utility._addLineFeedCodeIfNotNullString(shaderCode);
 	}
+
+	//TODO: remove needless precisions
+	private __createGlobalPrecisionShaderCode(): string {
+		let shaderCode = '';
+		for (const type in this.__globalPrecision) {
+			const precisionType = type as ShaderPrecisionObjectKey;
+			const precisionQualifier = this.__globalPrecision[precisionType];
+
+			shaderCode += `precision ${precisionQualifier} ${precisionType};\n`;
+		}
+
+		return Utility._addLineFeedCodeIfNotNullString(shaderCode);
+	}
 }
+

--- a/src/main/ShaderityObjectCreator.ts
+++ b/src/main/ShaderityObjectCreator.ts
@@ -94,6 +94,10 @@ export default class ShaderityObjectCreator {
 		this.__extensions.splice(matchedIndex, 1);
 	}
 
+	public updateGlobalPrecision(precision: ShaderPrecisionObject) {
+		Object.assign(this.__globalPrecision, precision);
+	}
+
 	public createShaderityObject(): ShaderityObject {
 		const shaderityObj = {
 			code: this.__createShaderCode(),

--- a/src/main/ShaderityObjectCreator.ts
+++ b/src/main/ShaderityObjectCreator.ts
@@ -2,6 +2,7 @@ import {
 	ShaderExtensionBehavior,
 	ShaderExtensionObject,
 	ShaderityObject,
+	ShaderPrecisionObject,
 	ShaderStageStr
 } from '../types/type';
 import Utility from './Utility';
@@ -14,7 +15,25 @@ export default class ShaderityObjectCreator {
 
 	private __defineDirectiveNames: string[] = [];
 	private __extensions: ShaderExtensionObject[] = [];
-	// global precision
+	private __globalPrecision: ShaderPrecisionObject = {
+		int: 'highp',
+		float: 'highp',
+		sampler2D: 'highp',
+		samplerCube: 'highp',
+		sampler3D: 'highp',
+		sampler2DArray: 'highp',
+		isampler2D: 'highp',
+		isamplerCube: 'highp',
+		isampler3D: 'highp',
+		isampler2DArray: 'highp',
+		usampler2D: 'highp',
+		usamplerCube: 'highp',
+		usampler3D: 'highp',
+		usampler2DArray: 'highp',
+		sampler2DShadow: 'highp',
+		samplerCubeShadow: 'highp',
+		sampler2DArrayShadow: 'highp',
+	};
 	// global constant value
 	// attribute declaration (for vertex shader)
 	// varying declaration

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -45,3 +45,25 @@ export type ShaderExtensionObject = {
 	extensionName: string, // e.g. GL_OES_standard_derivatives
 	behavior: ShaderExtensionBehavior,
 };
+
+export type ShaderPrecisionType = 'highp' | 'mediump' | 'lowp';
+
+export type ShaderPrecisionObject = {
+	int?: ShaderPrecisionType,
+	float?: ShaderPrecisionType,
+	sampler2D?: ShaderPrecisionType,
+	samplerCube?: ShaderPrecisionType,
+	sampler3D?: ShaderPrecisionType, // for es3
+	sampler2DArray?: ShaderPrecisionType, // for es3
+	isampler2D?: ShaderPrecisionType, // for es3
+	isamplerCube?: ShaderPrecisionType, // for es3
+	isampler3D?: ShaderPrecisionType, // for es3
+	isampler2DArray?: ShaderPrecisionType, // for es3
+	usampler2D?: ShaderPrecisionType, // for es3
+	usamplerCube?: ShaderPrecisionType, // for es3
+	usampler3D?: ShaderPrecisionType, // for es3
+	usampler2DArray?: ShaderPrecisionType, // for es3
+	sampler2DShadow?: ShaderPrecisionType, // for es3
+	samplerCubeShadow?: ShaderPrecisionType, // for es3
+	sampler2DArrayShadow?: ShaderPrecisionType, // for es3
+};

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -48,6 +48,25 @@ export type ShaderExtensionObject = {
 
 export type ShaderPrecisionType = 'highp' | 'mediump' | 'lowp';
 
+export type ShaderPrecisionObjectKey =
+	'int' |
+	'float' |
+	'sampler2D' |
+	'samplerCube' |
+	'sampler3D' |
+	'sampler2DArray' |
+	'isampler2D' |
+	'isamplerCube' |
+	'isampler3D' |
+	'isampler2DArray' |
+	'usampler2D' |
+	'usamplerCube' |
+	'usampler3D' |
+	'usampler2DArray' |
+	'sampler2DShadow' |
+	'samplerCubeShadow' |
+	'sampler2DArrayShadow';
+
 export type ShaderPrecisionObject = {
 	int?: ShaderPrecisionType,
 	float?: ShaderPrecisionType,

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -345,3 +345,32 @@ precision highp sampler2DArrayShadow;
 
 `);
 });
+
+test('test updateGlobalPrecision method in ShaderityObjectCreator', async() => {
+  const shaderityObjectCreator = Shaderity.createShaderityObjectCreator('vertex');
+  shaderityObjectCreator.updateGlobalPrecision({
+    int: 'mediump',
+    float: 'lowp',
+  });
+
+  const resultShaderityObj = shaderityObjectCreator.createShaderityObject();
+  expect(resultShaderityObj.code).toStrictEqual(`precision mediump int;
+precision lowp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
+`);
+});

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -238,6 +238,24 @@ test('test addDefineDirective method in ShaderityObjectCreator', async() => {
 #define testB B
 #define testC_c C
 
+precision highp int;
+precision highp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
 `);
 });
 
@@ -252,6 +270,24 @@ test('test removeDefineDirective method in ShaderityObjectCreator', async() => {
   expect(resultShaderityObj.code).toStrictEqual(`#define testA
 #define testC_c C
 
+precision highp int;
+precision highp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
 `);
 });
 
@@ -262,6 +298,24 @@ test('test addExtension method in ShaderityObjectCreator', async() => {
   const resultShaderityObj = shaderityObjectCreator.createShaderityObject();
   expect(resultShaderityObj.code).toStrictEqual(`#extension GL_OES_standard_derivatives: enable
 
+precision highp int;
+precision highp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
 `);
 });
 
@@ -271,5 +325,23 @@ test('test removeExtension method in ShaderityObjectCreator', async() => {
   shaderityObjectCreator.removeExtension('GL_OES_standard_derivatives', 'enable');
 
   const resultShaderityObj = shaderityObjectCreator.createShaderityObject();
-  expect(resultShaderityObj.code).toStrictEqual(``);
+  expect(resultShaderityObj.code).toStrictEqual(`precision highp int;
+precision highp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
+`);
 });


### PR DESCRIPTION
This PR allows the ShaderityObjectCreator class to edit precisions in the global scope.