### PR TITLE
feat: edit global constant struct initializations in shader creator

### DIFF
--- a/src/main/ShaderityObjectCreator.ts
+++ b/src/main/ShaderityObjectCreator.ts
@@ -219,6 +219,23 @@ export default class ShaderityObjectCreator {
 		this.__globalConstantValues.splice(matchedIndex, 1);
 	}
 
+	// need to define struct by the addStructDefinition method
+	// validate that the corresponding structure is defined by the __createGlobalConstantStructValueShaderCode method
+	public addGlobalConstantStructValue(structName: string, variableName: string, values: {[keyVariableName: string]: number[]}) {
+		const isDuplicate =
+			this.__globalConstantStructValues.some(structValue => structValue.variableName === variableName);
+		if (isDuplicate) {
+			console.error(`addGlobalConstantStructValue: duplicate variable name ${variableName}`);
+			return;
+		}
+
+		this.__globalConstantStructValues.push({
+			variableName,
+			structName,
+			values,
+		});
+	}
+
 	public addAttributeDeclaration(
 		variableName: string,
 		type: ShaderAttributeVarType,

--- a/src/main/ShaderityObjectCreator.ts
+++ b/src/main/ShaderityObjectCreator.ts
@@ -17,6 +17,7 @@ import {
 	ShaderUniformVarTypeES3,
 	ShaderStructDefinitionObject,
 	ShaderStructMemberObject,
+	ShaderConstantStructValueObject,
 } from '../types/type';
 import Utility from './Utility';
 
@@ -49,6 +50,7 @@ export default class ShaderityObjectCreator {
 	};
 	private __structDefinitions: ShaderStructDefinitionObject[] = [];
 	private __globalConstantValues: ShaderConstantValueObject[] = [];
+	private __globalConstantStructValues: ShaderConstantStructValueObject[] = [];
 	private __attributes: ShaderAttributeObject[] = []; // for vertex shader only
 	private __varyings: ShaderVaryingObject[] = [];
 	private __uniforms: ShaderUniformObject[] = [];

--- a/src/main/ShaderityObjectCreator.ts
+++ b/src/main/ShaderityObjectCreator.ts
@@ -236,6 +236,17 @@ export default class ShaderityObjectCreator {
 		});
 	}
 
+	public updateGlobalConstantStructValue(variableName: string, values: {[keyVariableName: string]: number[]}) {
+		const matchedIndex =
+			this.__globalConstantStructValues.findIndex(structValue => structValue.variableName === variableName);
+		if (matchedIndex === -1) {
+			console.error(`updateGlobalConstantStructValue:  the variable name ${variableName} is not exist`);
+			return;
+		}
+
+		this.__globalConstantStructValues[matchedIndex].values = values;
+	}
+
 	public addAttributeDeclaration(
 		variableName: string,
 		type: ShaderAttributeVarType,

--- a/src/main/ShaderityObjectCreator.ts
+++ b/src/main/ShaderityObjectCreator.ts
@@ -247,6 +247,17 @@ export default class ShaderityObjectCreator {
 		this.__globalConstantStructValues[matchedIndex].values = values;
 	}
 
+	public removeGlobalConstantStructValue(variableName: string) {
+		const matchedIndex =
+			this.__globalConstantStructValues.findIndex(structValue => structValue.variableName === variableName);
+		if (matchedIndex === -1) {
+			console.error(`updateGlobalConstantStructValue:  the variable name ${variableName} is not exist`);
+			return;
+		}
+
+		this.__globalConstantStructValues.splice(matchedIndex, 1);
+	}
+
 	public addAttributeDeclaration(
 		variableName: string,
 		type: ShaderAttributeVarType,

--- a/src/main/Utility.ts
+++ b/src/main/Utility.ts
@@ -63,11 +63,29 @@ export default class Utility {
 		}
 	}
 
-	static _isValidComponentCount(type: ShaderConstantValueVarTypeES3, values: number[]) {
+	static _isValidComponentCount(
+		type: ShaderConstantValueVarTypeES3 | ShaderAttributeVarType | ShaderVaryingVarType | ShaderUniformVarTypeES3,
+		values: number[]
+	) {
 		const validComponentCount = Utility._componentNumber(type);
 		if (validComponentCount === values.length) {
 			return true;
 		}
 		return false;
+	}
+
+	static _isSamplerType(
+		type: ShaderConstantValueVarTypeES3 | ShaderAttributeVarType | ShaderVaryingVarType | ShaderUniformVarTypeES3
+	) {
+		if (
+			type === 'sampler2D' || type === 'samplerCube' || type === 'sampler3D' || type === 'sampler2DArray' ||
+			type === 'isampler2D' || type === 'isamplerCube' || type === 'isampler3D' || type === 'isampler2DArray' ||
+			type === 'usampler2D' || type === 'usamplerCube' || type === 'usampler3D' || type === 'usampler2DArray' ||
+			type === 'sampler2DShadow' || type === 'samplerCubeShadow' || type === 'sampler2DArrayShadow'
+		) {
+			return true;
+		} else {
+			return false;
+		}
 	}
 }

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -120,6 +120,12 @@ export type ShaderConstantValueObject = {
 	values: number[],
 };
 
+export type ShaderConstantStructValueObject = {
+	structName: string,
+	variableName: string,
+	values: {[memberName: string]: number[]},
+}
+
 export type ShaderAttributeVarType =
 	'float' | 'vec2' | 'vec3' | 'vec4' |
 	'int' | 'ivec2' | 'ivec3' | 'ivec4' |

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -689,6 +689,269 @@ const ivec3 testIVec = ivec3(-7, 4, 5);
 `);
 });
 
+test('test addGlobalConstantStructValue method in ShaderityObjectCreator', async() => {
+  const shaderStructVariableObjectsA = [{
+      memberName: 'varA',
+      type: 'float',
+      precision: 'lowp',
+    },
+    {
+      memberName: 'varB',
+      type: 'mat2',
+    },
+  ];
+
+  const shaderStructVariableObjectsB = [{
+      memberName: 'varA',
+      type: 'float',
+    },
+    {
+      memberName: 'varB',
+      type: 'isampler2D',
+      precision: 'highp',
+    },
+    {
+      memberName: 'varC',
+      type: 'sampler3D',
+      precision: 'mediump',
+    },
+  ];
+
+  const structValueA = {
+    varA: [1.0],
+    varB: [1.3, 2, -5.1, -10.0],
+  };
+
+  const structValueB = {
+    varA: [-10.0],
+    varB: [13.1, -22.1, 1.4, 5],
+  };
+
+  const shaderityObjectCreator = Shaderity.createShaderityObjectCreator('vertex');
+  shaderityObjectCreator.addStructDefinition('testStructA', shaderStructVariableObjectsA);
+  shaderityObjectCreator.addStructDefinition('testStructB', shaderStructVariableObjectsB);
+
+  shaderityObjectCreator.addGlobalConstantStructValue('testStructA', 'structVarA', structValueA);
+  shaderityObjectCreator.addGlobalConstantStructValue('testStructA', 'structVarB', structValueB);
+
+  const resultShaderityObj = shaderityObjectCreator.createShaderityObject();
+  expect(resultShaderityObj.code).toStrictEqual(`precision highp int;
+precision highp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
+struct testStructA {
+  lowp float varA;
+  mat2 varB;
+};
+struct testStructB {
+  float varA;
+  highp isampler2D varB;
+  mediump sampler3D varC;
+};
+
+const testStructA structVarA = testStructA (
+  float(1),
+  mat2(1.3, 2, -5.1, -10)
+);
+const testStructA structVarB = testStructA (
+  float(-10),
+  mat2(13.1, -22.1, 1.4, 5)
+);
+
+`);
+});
+
+test('test updateGlobalConstantStructValue method in ShaderityObjectCreator', async() => {
+  const shaderStructVariableObjectsA = [{
+      memberName: 'varA',
+      type: 'float',
+      precision: 'lowp',
+    },
+    {
+      memberName: 'varB',
+      type: 'mat2',
+    },
+  ];
+
+  const shaderStructVariableObjectsB = [{
+      memberName: 'varA',
+      type: 'float',
+    },
+    {
+      memberName: 'varB',
+      type: 'isampler2D',
+      precision: 'highp',
+    },
+    {
+      memberName: 'varC',
+      type: 'sampler3D',
+      precision: 'mediump',
+    },
+  ];
+
+  const structValueA = {
+    varA: [1.0],
+    varB: [1.3, 2, -5.1, -10.0],
+  };
+
+  const structValueB = {
+    varA: [-10.0],
+    varB: [13.1, -22.1, 1.4, 5],
+  };
+
+  const structValueC = {
+    varA: [10.0],
+    varB: [13.1, -22.1, 1.4, 5],
+  };
+
+  const shaderityObjectCreator = Shaderity.createShaderityObjectCreator('vertex');
+  shaderityObjectCreator.addStructDefinition('testStructA', shaderStructVariableObjectsA);
+  shaderityObjectCreator.addStructDefinition('testStructB', shaderStructVariableObjectsB);
+
+  shaderityObjectCreator.addGlobalConstantStructValue('testStructA', 'structVarA', structValueA);
+  shaderityObjectCreator.addGlobalConstantStructValue('testStructA', 'structVarB', structValueB);
+
+  shaderityObjectCreator.updateGlobalConstantStructValue('structVarB', structValueC);
+
+  const resultShaderityObj = shaderityObjectCreator.createShaderityObject();
+  expect(resultShaderityObj.code).toStrictEqual(`precision highp int;
+precision highp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
+struct testStructA {
+  lowp float varA;
+  mat2 varB;
+};
+struct testStructB {
+  float varA;
+  highp isampler2D varB;
+  mediump sampler3D varC;
+};
+
+const testStructA structVarA = testStructA (
+  float(1),
+  mat2(1.3, 2, -5.1, -10)
+);
+const testStructA structVarB = testStructA (
+  float(10),
+  mat2(13.1, -22.1, 1.4, 5)
+);
+
+`);
+});
+
+test('test removeGlobalConstantStructValue method in ShaderityObjectCreator', async() => {
+  const shaderStructVariableObjectsA = [{
+      memberName: 'varA',
+      type: 'float',
+      precision: 'lowp',
+    },
+    {
+      memberName: 'varB',
+      type: 'mat2',
+    },
+  ];
+
+  const shaderStructVariableObjectsB = [{
+      memberName: 'varA',
+      type: 'float',
+    },
+    {
+      memberName: 'varB',
+      type: 'isampler2D',
+      precision: 'highp',
+    },
+    {
+      memberName: 'varC',
+      type: 'sampler3D',
+      precision: 'mediump',
+    },
+  ];
+
+  const structValueA = {
+    varA: [1.0],
+    varB: [1.3, 2, -5.1, -10.0],
+  };
+
+  const structValueB = {
+    varA: [-10.0],
+    varB: [13.1, -22.1, 1.4, 5],
+  };
+
+  const shaderityObjectCreator = Shaderity.createShaderityObjectCreator('vertex');
+  shaderityObjectCreator.addStructDefinition('testStructA', shaderStructVariableObjectsA);
+  shaderityObjectCreator.addStructDefinition('testStructB', shaderStructVariableObjectsB);
+
+  shaderityObjectCreator.addGlobalConstantStructValue('testStructA', 'structVarA', structValueA);
+  shaderityObjectCreator.addGlobalConstantStructValue('testStructA', 'structVarB', structValueB);
+
+  shaderityObjectCreator.removeGlobalConstantStructValue('structVarA');
+
+  const resultShaderityObj = shaderityObjectCreator.createShaderityObject();
+  expect(resultShaderityObj.code).toStrictEqual(`precision highp int;
+precision highp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
+struct testStructA {
+  lowp float varA;
+  mat2 varB;
+};
+struct testStructB {
+  float varA;
+  highp isampler2D varB;
+  mediump sampler3D varC;
+};
+
+const testStructA structVarB = testStructA (
+  float(-10),
+  mat2(13.1, -22.1, 1.4, 5)
+);
+
+`);
+});
+
 test('test addAttribute method in ShaderityObjectCreator', async() => {
   const shaderityObjectCreator = Shaderity.createShaderityObjectCreator('vertex');
   shaderityObjectCreator.addAttributeDeclaration('a_testA', 'float');


### PR DESCRIPTION
This PR allows the ShaderityObjectCreator class to edit global constant struct values.