### PR TITLE
feat: remove needless global precision when converting to shader for es1

### DIFF
--- a/assets/insert_definition_es3.vert
+++ b/assets/insert_definition_es3.vert
@@ -1,5 +1,5 @@
 in vec3 position;
 
-void main (void) {
+void main () {
   gl_Position = vec4(position, 1.0);
 }

--- a/assets/layout_uniform_es3.frag
+++ b/assets/layout_uniform_es3.frag
@@ -4,7 +4,7 @@ layout(location = 0) uniform sampler2D u_texture;
 layout(location = 1) uniform samplerCube u_textureCube;
 
 
-void main (void) {
+void main () {
   gl_FragColor = texture2D(u_texture, v_texcoord);
   gl_FragColor = textureCube(u_textureCube, v_texcoord3);
   gl_FragColor = texture2DProj(u_texture, v_texcoord);

--- a/assets/precision_es3.vert
+++ b/assets/precision_es3.vert
@@ -1,0 +1,21 @@
+#version 300 es
+
+precision mediump int;
+precision lowp float;
+precision highp sampler2D;
+precision highp samplerCube;
+precision highp sampler3D;
+precision highp sampler2DArray;
+precision highp isampler2D;
+precision highp isamplerCube;
+precision highp isampler3D;
+precision highp isampler2DArray;
+precision highp usampler2D;
+precision highp usamplerCube;
+precision highp usampler3D;
+precision highp usampler2DArray;
+precision highp sampler2DShadow;
+precision highp samplerCubeShadow;
+precision highp sampler2DArrayShadow;
+
+void main() {}

--- a/assets/simple_es3.vert
+++ b/assets/simple_es3.vert
@@ -3,7 +3,7 @@ in vec4 color;
 uniform mat4 matrix;
 out vec4 vColor;
 
-void main (void) {
+void main () {
   vColor = color;
   gl_Position = matrix * position;
 }

--- a/assets/texture_es1.frag
+++ b/assets/texture_es1.frag
@@ -7,7 +7,7 @@ uniform sampler2D u_texture;
 uniform sampler3D u_texture_3D;
 uniform samplerCube u_textureCube;
 
-void main (void) {
+void main () {
   gl_FragColor = texture2D(u_texture, v_texcoord);
   gl_FragColor = textureCube(u_textureCube, v_texcoord3);
   gl_FragColor = texture2DProj(u_texture, v_texcoord);

--- a/assets/texture_es3.frag
+++ b/assets/texture_es3.frag
@@ -6,7 +6,7 @@ uniform sampler2D u_texture;
 uniform sampler3D u_texture_3D;
 uniform samplerCube u_textureCube;
 
-void main (void) {
+void main () {
   gl_FragColor = texture(u_texture, v_texcoord);
   gl_FragColor = texture(u_textureCube, v_texcoord3);
   gl_FragColor = textureProj(u_texture, v_texcoord);

--- a/assets/texture_func_es3.frag
+++ b/assets/texture_func_es3.frag
@@ -21,7 +21,7 @@ void fetch2(
   gl_FragColor = textureProj(texture1, v_texcoord);
 }
 
-void main (void) {
+void main () {
   fetch(texture2, texture1);
   fetch2(texture2, texture1);
 }

--- a/src_for_test/index_test.js
+++ b/src_for_test/index_test.js
@@ -8,6 +8,7 @@ import insertDefinitionVertexShader from '../assets/insert_definition_es3.vert';
 import reflectionVertexES1Shader from '../assets/reflection_es1.vert';
 import reflectionVertexES3Shader from '../assets/reflection_es3.vert';
 import layoutUniformFragmentES3Shader from '../assets/layout_uniform_es3.frag';
+import precisionES3Shader from '../assets/precision_es3.vert';
 
 exports.simpleFragment = simpleFragmentShader;
 exports.simpleVertex = simpleVertexShader;
@@ -19,3 +20,4 @@ exports.insertDefinitionVertex = insertDefinitionVertexShader;
 exports.reflectionVertexES1 = reflectionVertexES1Shader;
 exports.reflectionVertexES3 = reflectionVertexES3Shader;
 exports.layoutUniformFragmentES3 = layoutUniformFragmentES3Shader;
+exports.precisionES3 = precisionES3Shader;

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -9,6 +9,7 @@ const insertDefinitionVertex = require('../dist/index_test').insertDefinitionVer
 const reflectionVertexES1 = require('../dist/index_test').reflectionVertexES1;
 const reflectionVertexES3 = require('../dist/index_test').reflectionVertexES3;
 const layoutUniformFragmentES3 = require('../dist/index_test').layoutUniformFragmentES3;
+const precisionES3 = require('../dist/index_test').precisionES3;
 
 
 test('detect shader stage correctly', async() => {
@@ -225,6 +226,19 @@ void main (void) {
     type: 'samplerCube',
     semantic: 'UNKNOWN'
   });
+});
+
+test('test precision translation from ES3 shader to ES1 shader', async() => {
+  const shaderityObject = Shaderity.transformToGLSLES1(precisionES3);
+  expect(shaderityObject.code).toBe(`#version 100
+
+precision mediump int;
+precision lowp float;
+precision highp sampler2D;
+precision highp samplerCube;
+
+void main() {}
+`);
 });
 
 test('test addDefineDirective method in ShaderityObjectCreator', async() => {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -37,7 +37,7 @@ attribute vec4 color;
 uniform mat4 matrix;
 varying vec4 vColor;
 
-void main (void) {
+void main () {
   vColor = color;
   gl_Position = matrix * position;
 }
@@ -55,7 +55,7 @@ uniform sampler2D u_texture;
 uniform sampler3D u_texture_3D;
 uniform samplerCube u_textureCube;
 
-void main (void) {
+void main () {
   gl_FragColor = texture(u_texture, v_texcoord);
   gl_FragColor = texture(u_textureCube, v_texcoord3);
   gl_FragColor = textureProj(u_texture, v_texcoord);
@@ -74,7 +74,7 @@ uniform sampler2D u_texture;
 uniform sampler3D u_texture_3D;
 uniform samplerCube u_textureCube;
 
-void main (void) {
+void main () {
   gl_FragColor = texture2D(u_texture, v_texcoord);
   gl_FragColor = textureCube(u_textureCube, v_texcoord3);
   gl_FragColor = texture2DProj(u_texture, v_texcoord);
@@ -109,7 +109,7 @@ void fetch2(
   gl_FragColor = texture2DProj(texture1, v_texcoord);
 }
 
-void main (void) {
+void main () {
   fetch(texture2, texture1);
   fetch2(texture2, texture1);
 }
@@ -141,7 +141,7 @@ test('test insert definition', async() => {
   expect(Shaderity.insertDefinition(insertDefinitionVertex, 'GLSL_ES3').code).toBe(`#define GLSL_ES3
 in vec3 position;
 
-void main (void) {
+void main () {
   gl_Position = vec4(position, 1.0);
 }
 `);
@@ -212,7 +212,7 @@ uniform sampler2D u_texture;
 uniform samplerCube u_textureCube;
 
 
-void main (void) {
+void main () {
   gl_FragColor = texture2D(u_texture, v_texcoord);
   gl_FragColor = textureCube(u_textureCube, v_texcoord3);
   gl_FragColor = texture2DProj(u_texture, v_texcoord);


### PR DESCRIPTION
This PR support #70.