### PR TITLE
chore: change default value of extension behavior to improve usability

### DIFF
--- a/src/main/ShaderityObjectCreator.ts
+++ b/src/main/ShaderityObjectCreator.ts
@@ -84,7 +84,7 @@ export default class ShaderityObjectCreator {
 		this.__defineDirectiveNames.push(defineDirectiveName);
 	}
 
-	public addExtension(extensionName: string, behavior: ShaderExtensionBehavior = 'require') {
+	public addExtension(extensionName: string, behavior: ShaderExtensionBehavior = 'enable') {
 		const isDuplicate =
 			this.__extensions.some(extension => extension.extensionName === extensionName);
 		if (isDuplicate) {


### PR DESCRIPTION
This PR changes the default value of extension behavior in ShaderObjectCreator from 'require' to 'enable'.

The difference is the behavior when the extension is not supported. If it is 'enable', it only gives a warning, if it is 'require', it fails.