### PR TITLE
refactor: export types of ShaderityObjectCreator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import Shaderity from './main/Shaderity';
+import _ShaderityObjectCreator from './main/ShaderityObjectCreator';
+import _Reflection from './main/Reflection';
 
 import {
   AttributeSemantics as _AttributeSemantics,
@@ -32,6 +34,11 @@ import {
   VarType as _VarType,
 } from './types/type';
 
+export {
+  ShaderityObjectCreator as _ShaderityObjectCreator,
+  Reflection as _Reflection,
+}
+
 export type AttributeSemantics = _AttributeSemantics;
 export type ReflectionAttribute = _ReflectionAttribute;
 export type ReflectionUniform = _ReflectionUniform;
@@ -61,5 +68,7 @@ export type ShaderVersion = _ShaderVersion;
 export type TemplateObject = _TemplateObject;
 export type UniformSemantics = _UniformSemantics;
 export type VarType = _VarType;
+export type ShaderityObjectCreator = _ShaderityObjectCreator;
+export type Reflection = _Reflection;
 
 export default Shaderity

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,48 +1,65 @@
 import Shaderity from './main/Shaderity';
+
 import {
-  AttributeSemantics,
-  ReflectionAttribute,
-  ReflectionUniform,
-  ReflectionVarying,
-  ShaderityObject,
-  ShaderExtensionBehavior,
-  ShaderConstantValueVarTypeES3,
-  ShaderPrecisionObject,
-  ShaderStageStr,
-  ShaderPrecisionType,
-  ShaderAttributeVarType,
-  ShaderVaryingInterpolationType,
-  ShaderVaryingVarType,
-  ShaderUniformVarTypeES3,
-  ShaderStructMemberObject,
-  ShaderUBOVariableObject,
-  ShaderVersion,
-  TemplateObject,
-  UniformSemantics,
-  VarType,
+  AttributeSemantics as _AttributeSemantics,
+  ReflectionAttribute as _ReflectionAttribute,
+  ReflectionUniform as _ReflectionUniform,
+  ReflectionVarying as _ReflectionVarying,
+  ShaderityObject as _ShaderityObject,
+  ShaderExtensionBehavior as _ShaderExtensionBehavior,
+  ShaderConstantValueVarTypeES3 as _ShaderConstantValueVarTypeES3,
+  ShaderPrecisionObject as _ShaderPrecisionObject,
+  ShaderStageStr as _ShaderStageStr,
+  ShaderPrecisionType as _ShaderPrecisionType,
+  ShaderAttributeVarType as _ShaderAttributeVarType,
+  ShaderVaryingInterpolationType as _ShaderVaryingInterpolationType,
+  ShaderVaryingVarType as _ShaderVaryingVarType,
+  ShaderUniformVarTypeES3 as _ShaderUniformVarTypeES3,
+  ShaderStructMemberObject as _ShaderStructMemberObject,
+  ShaderUBOVariableObject as _ShaderUBOVariableObject,
+  ShaderAttributeObject as _ShaderAttributeObject,
+  ShaderConstantStructValueObject as _ShaderConstantStructValueObject,
+  ShaderConstantValueObject as _ShaderConstantValueObject,
+  ShaderExtensionObject as _ShaderExtensionObject,
+  ShaderStructDefinitionObject as _ShaderStructDefinitionObject,
+  ShaderUniformBufferObject as _ShaderUniformBufferObject,
+  ShaderUniformObject as _ShaderUniformObject,
+  ShaderUniformStructObject as _ShaderUniformStructObject,
+  ShaderVaryingObject as _ShaderVaryingObject,
+  ShaderVersion as _ShaderVersion,
+  TemplateObject as _TemplateObject,
+  UniformSemantics as _UniformSemantics,
+  VarType as _VarType,
 } from './types/type';
 
-export type {
-  AttributeSemantics,
-  ReflectionAttribute,
-  ReflectionUniform,
-  ReflectionVarying,
-  ShaderityObject,
-  ShaderExtensionBehavior,
-  ShaderConstantValueVarTypeES3,
-  ShaderPrecisionObject,
-  ShaderStageStr,
-  ShaderPrecisionType,
-  ShaderAttributeVarType,
-  ShaderVaryingInterpolationType,
-  ShaderVaryingVarType,
-  ShaderUniformVarTypeES3,
-  ShaderStructMemberObject,
-  ShaderUBOVariableObject,
-  ShaderVersion,
-  TemplateObject,
-  UniformSemantics,
-  VarType,
-}
+export type AttributeSemantics = _AttributeSemantics;
+export type ReflectionAttribute = _ReflectionAttribute;
+export type ReflectionUniform = _ReflectionUniform;
+export type ReflectionVarying = _ReflectionVarying;
+export type ShaderityObject = _ShaderityObject;
+export type ShaderExtensionBehavior = _ShaderExtensionBehavior;
+export type ShaderConstantValueVarTypeES3 = _ShaderConstantValueVarTypeES3;
+export type ShaderPrecisionObject = _ShaderPrecisionObject;
+export type ShaderStageStr = _ShaderStageStr;
+export type ShaderPrecisionType = _ShaderPrecisionType;
+export type ShaderAttributeVarType = _ShaderAttributeVarType;
+export type ShaderVaryingInterpolationType = _ShaderVaryingInterpolationType;
+export type ShaderVaryingVarType = _ShaderVaryingVarType;
+export type ShaderUniformVarTypeES3 = _ShaderUniformVarTypeES3;
+export type ShaderStructMemberObject = _ShaderStructMemberObject;
+export type ShaderUBOVariableObject = _ShaderUBOVariableObject;
+export type ShaderAttributeObject = _ShaderAttributeObject;
+export type ShaderConstantStructValueObject = _ShaderConstantStructValueObject;
+export type ShaderConstantValueObject = _ShaderConstantValueObject;
+export type ShaderExtensionObject = _ShaderExtensionObject;
+export type ShaderStructDefinitionObject = _ShaderStructDefinitionObject;
+export type ShaderUniformBufferObject = _ShaderUniformBufferObject;
+export type ShaderUniformObject = _ShaderUniformObject;
+export type ShaderUniformStructObject = _ShaderUniformStructObject;
+export type ShaderVaryingObject = _ShaderVaryingObject;
+export type ShaderVersion = _ShaderVersion;
+export type TemplateObject = _TemplateObject;
+export type UniformSemantics = _UniformSemantics;
+export type VarType = _VarType;
 
 export default Shaderity

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -25,13 +25,13 @@ export type ReflectionUniform = {
 	name: string,
 	type: string,
 	semantic: string
-}
+};
 
 export type ReflectionVarying = {
 	name: string,
 	inout: "in" | "out",
 	type: VarType
-}
+};
 
 export type TemplateObject = {
 	[key: string]: string | TemplateObject
@@ -91,12 +91,12 @@ export type ShaderStructMemberObject = {
 	memberName: string,
 	type: ShaderUniformVarTypeES3,
 	precision?: ShaderPrecisionType,
-}
+};
 
 export type ShaderStructDefinitionObject = {
 	structName: string,
 	memberObjects: ShaderStructMemberObject[],
-}
+};
 
 export type ShaderConstantValueVarTypeES1 =
 	'float' | 'vec2' | 'vec3' | 'vec4' |
@@ -124,7 +124,7 @@ export type ShaderConstantStructValueObject = {
 	structName: string,
 	variableName: string,
 	values: {[memberName: string]: number[]},
-}
+};
 
 export type ShaderAttributeVarType =
 	'float' | 'vec2' | 'vec3' | 'vec4' |
@@ -187,7 +187,7 @@ export type ShaderUBOVarType = ShaderConstantValueVarTypeES3;
 export type ShaderUBOVariableObject = {
 	type: ShaderUBOVarType,
 	variableName: string,
-}
+};
 
 export type ShaderUniformBufferObject = {
 	blockName: string,


### PR DESCRIPTION
Output the type of ShaderityObjectCreator for simplicity when calling ShaderityObjectCreator from another library.